### PR TITLE
add solution without dependencies on example projects

### DIFF
--- a/OnnxStackCore.sln
+++ b/OnnxStackCore.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OnnxStack.Core", "OnnxStack.Core\OnnxStack.Core.csproj", "{D05A6B4D-A906-482D-9A12-42346FFA9159}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OnnxStack.StableDiffusion", "OnnxStack.StableDiffusion\OnnxStack.StableDiffusion.csproj", "{93F03618-9D5D-40E3-A565-729D72B164BB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D05A6B4D-A906-482D-9A12-42346FFA9159}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D05A6B4D-A906-482D-9A12-42346FFA9159}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D05A6B4D-A906-482D-9A12-42346FFA9159}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D05A6B4D-A906-482D-9A12-42346FFA9159}.Release|Any CPU.Build.0 = Release|Any CPU
+		{93F03618-9D5D-40E3-A565-729D72B164BB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{93F03618-9D5D-40E3-A565-729D72B164BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{93F03618-9D5D-40E3-A565-729D72B164BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{93F03618-9D5D-40E3-A565-729D72B164BB}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Addresses https://github.com/saddam213/OnnxStack/issues/12

In practice might be nicer to have the solution file that contains the core project and the support for specific ONNX models be the project named `OnnxStack.sln` and the one that contains the example usage applications be something like `Examples.sln`. I'm guessing it's all in one single solution as that's the easiest in terms of work flow as you can directly reference the library code inside the UI projects without having to go through the process of compiling it and building a NuGet package, and then adding that NuGet package into the sample apps as you work. Though, no reason the `Examples.sln` couldn't also contain all the things, it's just it would feel slightly clearer if the core library and support for models  were the thing named `OnnxStack.sln`, but that's just my 2c. 