### PR TITLE
Initial Float16 and BFloat16 onnx type  support

### DIFF
--- a/OnnxStack.StableDiffusion/Diffusers/LatentConsistency/LatentConsistencyDiffuser.cs
+++ b/OnnxStack.StableDiffusion/Diffusers/LatentConsistency/LatentConsistencyDiffuser.cs
@@ -107,6 +107,9 @@ namespace OnnxStack.StableDiffusion.Diffusers.LatentConsistency
                 var inputNames = _onnxModelService.GetInputNames(modelOptions, OnnxModelType.Unet);
                 var outputNames = _onnxModelService.GetOutputNames(modelOptions, OnnxModelType.Unet);
                 var inputMetaData = _onnxModelService.GetInputMetadata(modelOptions, OnnxModelType.Unet);
+                var outputMetaData = _onnxModelService.GetOutputMetadata(modelOptions, OnnxModelType.Unet);
+                var timestepMetaData = inputMetaData[inputNames[1]];
+                var outputTensorMetaData = outputMetaData[outputNames[0]];
 
                 // Loop though the timesteps
                 var step = 0;
@@ -120,17 +123,17 @@ namespace OnnxStack.StableDiffusion.Diffusers.LatentConsistency
                     var inputTensor = scheduler.ScaleInput(latents, timestep);
 
                     var outputChannels = 1;
-                    var outputBuffer = new DenseTensor<float>(schedulerOptions.GetScaledDimension(outputChannels));
-                    using (var outputTensorValue = outputBuffer.ToOrtValue())
-                    using (var inputTensorValue = inputTensor.ToOrtValue())
-                    using (var timestepOrtValue = CreateTimestepNamedOrtValue(inputMetaData, inputNames[1], timestep))
-                    using (var promptTensorValue = promptEmbeddings.ToOrtValue())
-                    using (var guidanceTensorValue = guidanceEmbeddings.ToOrtValue())
+                    var outputDimension = schedulerOptions.GetScaledDimension(outputChannels);
+                    using (var outputTensorValue = outputTensorMetaData.CreateOutputBuffer(outputDimension))
+                    using (var inputTensorValue = inputTensor.ToOrtValue(outputTensorMetaData))
+                    using (var promptTensorValue = promptEmbeddings.ToOrtValue(outputTensorMetaData))
+                    using (var guidanceTensorValue = guidanceEmbeddings.ToOrtValue(outputTensorMetaData))
+                    using (var timestepTensorValue = CreateTimestepNamedOrtValue(timestepMetaData, timestep))
                     {
                         var inputs = new Dictionary<string, OrtValue>
                         {
                             { inputNames[0], inputTensorValue },
-                            { inputNames[1], timestepOrtValue },
+                            { inputNames[1], timestepTensorValue },
                             { inputNames[2], promptTensorValue },
                             { inputNames[3], guidanceTensorValue }
                         };
@@ -139,7 +142,7 @@ namespace OnnxStack.StableDiffusion.Diffusers.LatentConsistency
                         var results = await _onnxModelService.RunInferenceAsync(modelOptions, OnnxModelType.Unet, inputs, outputs);
                         using (var result = results.First())
                         {
-                            var noisePred = outputBuffer;
+                            var noisePred = outputTensorValue.ToDenseTensor();
 
                             // Scheduler Step
                             var schedulerResult = scheduler.Step(noisePred, timestep, latents);

--- a/OnnxStack.StableDiffusion/Diffusers/StableDiffusion/ImageDiffuser.cs
+++ b/OnnxStack.StableDiffusion/Diffusers/StableDiffusion/ImageDiffuser.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.ML.OnnxRuntime;
 using Microsoft.ML.OnnxRuntime.Tensors;
+using OnnxStack.Core;
 using OnnxStack.Core.Config;
 using OnnxStack.Core.Services;
 using OnnxStack.StableDiffusion.Common;
@@ -12,7 +13,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using OnnxStack.Core;
 
 namespace OnnxStack.StableDiffusion.Diffusers.StableDiffusion
 {
@@ -63,19 +63,22 @@ namespace OnnxStack.StableDiffusion.Diffusers.StableDiffusion
             var imageTensor = prompt.InputImage.ToDenseTensor(new[] { 1, 3, options.Height, options.Width });
             var inputNames = _onnxModelService.GetInputNames(model, OnnxModelType.VaeEncoder);
             var outputNames = _onnxModelService.GetOutputNames(model, OnnxModelType.VaeEncoder);
+            var outputMetaData = _onnxModelService.GetOutputMetadata(model, OnnxModelType.VaeEncoder);
+            var outputTensorMetaData = outputMetaData[outputNames[0]];
 
             //TODO: Model Config, Channels
-            var outputBuffer = new DenseTensor<float>(options.GetScaledDimension());
-            using (var inputTensorValue = imageTensor.ToOrtValue())
-            using (var outputTensorValue = outputBuffer.ToOrtValue())
+            var outputDimension = options.GetScaledDimension();
+            using (var inputTensorValue = imageTensor.ToOrtValue(outputTensorMetaData))
+            using (var outputTensorValue = outputTensorMetaData.CreateOutputBuffer(outputDimension))
             {
                 var inputs = new Dictionary<string, OrtValue> { { inputNames[0], inputTensorValue } };
                 var outputs = new Dictionary<string, OrtValue> { { outputNames[0], outputTensorValue } };
                 var results = await _onnxModelService.RunInferenceAsync(model, OnnxModelType.VaeEncoder, inputs, outputs);
                 using (var result = results.First())
                 {
-                    var scaledSample = outputBuffer
-                       .Add(scheduler.CreateRandomSample(outputBuffer.Dimensions, options.InitialNoiseLevel))
+                    var outputResult = outputTensorValue.ToDenseTensor();
+                    var scaledSample = outputResult
+                       .Add(scheduler.CreateRandomSample(outputDimension, options.InitialNoiseLevel))
                        .MultiplyBy(model.ScaleFactor);
 
                     return scheduler.AddNoise(scaledSample, scheduler.CreateRandomSample(scaledSample.Dimensions), timesteps);

--- a/OnnxStack.StableDiffusion/Diffusers/StableDiffusion/StableDiffusionDiffuser.cs
+++ b/OnnxStack.StableDiffusion/Diffusers/StableDiffusion/StableDiffusionDiffuser.cs
@@ -61,6 +61,9 @@ namespace OnnxStack.StableDiffusion.Diffusers.StableDiffusion
                 var inputNames = _onnxModelService.GetInputNames(modelOptions, OnnxModelType.Unet);
                 var outputNames = _onnxModelService.GetOutputNames(modelOptions, OnnxModelType.Unet);
                 var inputMetaData = _onnxModelService.GetInputMetadata(modelOptions, OnnxModelType.Unet);
+                var outputMetaData = _onnxModelService.GetOutputMetadata(modelOptions, OnnxModelType.Unet);
+                var outputTensorMetaData = outputMetaData[outputNames[0]];
+                var timestepMetaData = inputMetaData[inputNames[1]];
 
                 // Loop though the timesteps
                 var step = 0;
@@ -75,16 +78,16 @@ namespace OnnxStack.StableDiffusion.Diffusers.StableDiffusion
                     var inputTensor = scheduler.ScaleInput(inputLatent, timestep);
 
                     var outputChannels = performGuidance ? 2 : 1;
-                    var outputBuffer = new DenseTensor<float>(schedulerOptions.GetScaledDimension(outputChannels));
-                    using (var outputTensorValue = outputBuffer.ToOrtValue())
-                    using (var inputTensorValue = inputTensor.ToOrtValue())
-                    using (var timestepOrtValue = CreateTimestepNamedOrtValue(inputMetaData, inputNames[1], timestep))
-                    using (var promptTensorValue = promptEmbeddings.ToOrtValue())
+                    var outputDimension = schedulerOptions.GetScaledDimension(outputChannels);
+                    using (var outputTensorValue = outputTensorMetaData.CreateOutputBuffer(outputDimension))
+                    using (var inputTensorValue = inputTensor.ToOrtValue(outputTensorMetaData))
+                    using (var promptTensorValue = promptEmbeddings.ToOrtValue(outputTensorMetaData))
+                    using (var timestepTensorValue = CreateTimestepNamedOrtValue(timestepMetaData, timestep))
                     {
                         var inputs = new Dictionary<string, OrtValue>
                         {
                             { inputNames[0], inputTensorValue },
-                            { inputNames[1], timestepOrtValue },
+                            { inputNames[1], timestepTensorValue },
                             { inputNames[2], promptTensorValue }
                         };
 
@@ -92,7 +95,7 @@ namespace OnnxStack.StableDiffusion.Diffusers.StableDiffusion
                         var results = await _onnxModelService.RunInferenceAsync(modelOptions, OnnxModelType.Unet, inputs, outputs);
                         using (var result = results.First())
                         {
-                            var noisePred = outputBuffer;
+                            var noisePred = result.ToDenseTensor();
 
                             // Perform guidance
                             if (performGuidance)


### PR DESCRIPTION
Add initial support for ONNX native `Float16` and `BFloat16` types
[Issue: 30](https://github.com/saddam213/OnnxStack/issues/30)

The main advantage of these types will be in native code during inference, we do little work with tensors outside inference, the schedulers are the most work, but its light and I would no expect too much gain on CPU using these types.

So this PR will use the NodeMetaData from the model to create the correct type native memory buffers, so all inference will be in the models native type, once inference is complete we cast back to `float`

In most cases we don't pass the output data into another session, TextEncoder, VaeEncode/Decoder just use the output and dispose, the scheduler steps however could benefit from staying in its native type, but that would require making the schedulers generic which would be quite a task, so I think perhaps measuring performance first may be a good option before getting too deep


TL;DR; Type support on native, cast back to `float` in managed
