### PR TITLE
Corrected the logger classes in the ImageInpaint and ImageToImage views

### DIFF
--- a/OnnxStack.UI/Views/ImageInpaint.xaml.cs
+++ b/OnnxStack.UI/Views/ImageInpaint.xaml.cs
@@ -25,7 +25,7 @@ namespace OnnxStack.UI.Views
     /// </summary>
     public partial class ImageInpaint : UserControl, INavigatable, INotifyPropertyChanged
     {
-        private readonly ILogger<TextToImageView> _logger;
+        private readonly ILogger<ImageInpaint> _logger;
         private readonly IStableDiffusionService _stableDiffusionService;
 
         private bool _hasResult;
@@ -52,7 +52,7 @@ namespace OnnxStack.UI.Views
         {
             if (!DesignerProperties.GetIsInDesignMode(this))
             {
-                _logger = App.GetService<ILogger<TextToImageView>>();
+                _logger = App.GetService<ILogger<ImageInpaint>>();
                 _stableDiffusionService = App.GetService<IStableDiffusionService>();
             }
 

--- a/OnnxStack.UI/Views/ImageToImage.xaml.cs
+++ b/OnnxStack.UI/Views/ImageToImage.xaml.cs
@@ -26,7 +26,7 @@ namespace OnnxStack.UI.Views
     /// </summary>
     public partial class ImageToImage : UserControl, INavigatable, INotifyPropertyChanged
     {
-        private readonly ILogger<TextToImageView> _logger;
+        private readonly ILogger<ImageToImage> _logger;
         private readonly IStableDiffusionService _stableDiffusionService;
 
         private bool _hasResult;
@@ -51,7 +51,7 @@ namespace OnnxStack.UI.Views
         {
             if (!DesignerProperties.GetIsInDesignMode(this))
             {
-                _logger = App.GetService<ILogger<TextToImageView>>();
+                _logger = App.GetService<ILogger<ImageToImage>>();
                 _stableDiffusionService = App.GetService<IStableDiffusionService>();
             }
 


### PR DESCRIPTION
The logger for the ImageInpaint and ImageToImage views were referencing the TextToImageView class, so I changed them to be their own respective view classes.

Also FYI the naming of the TextToImageView class does not match the naming of the ImageInpaint and ImageToImage view classes.