### PR TITLE
fix: 'IStableDiffusionService' does not contain a definition for 'Models' and no accessible extension method 'Mode ls' accepting a first argument of type 'IStableDiffusionService' could be found

### DIFF
--- a/OnnxStack.IntegrationTests/StableDiffusionTests.cs
+++ b/OnnxStack.IntegrationTests/StableDiffusionTests.cs
@@ -40,7 +40,7 @@ public class StableDiffusionTests
     public async Task GivenAStableDiffusionModel_WhenLoadModel_ThenModelIsLoaded(string modelName)
     {
         //arrange
-        var model = _stableDiffusion.Models.Single(m => m.Name == modelName);
+        var model = _stableDiffusion.ModelSets.Single(m => m.Name == modelName);
         
         //act
         _logger.LogInformation("Attempting to load model {0}", model.Name);
@@ -58,7 +58,7 @@ public class StableDiffusionTests
 
     {
         //arrange
-        var model = _stableDiffusion.Models.Single(m => m.Name == modelName);
+        var model = _stableDiffusion.ModelSets.Single(m => m.Name == modelName);
         _logger.LogInformation("Attempting to load model: {0}", model.Name);
         await _stableDiffusion.LoadModelAsync(model);
 
@@ -82,9 +82,9 @@ public class StableDiffusionTests
         var steps = 0;
 
         //act
-        var image = await _stableDiffusion.GenerateAsImageAsync(model, prompt, scheduler, (currentStep, totalSteps) =>
+        var image = await _stableDiffusion.GenerateAsImageAsync(model, prompt, scheduler, (currentStep) =>
         {
-            _logger.LogInformation($"Step {currentStep}/{totalSteps}");
+            _logger.LogInformation($"Step {currentStep}/{inferenceSteps}");
             steps++;
         });
 

--- a/OnnxStack.StableDiffusion/Common/IStableDiffusionService.cs
+++ b/OnnxStack.StableDiffusion/Common/IStableDiffusionService.cs
@@ -13,6 +13,8 @@ namespace OnnxStack.StableDiffusion.Common
 {
     public interface IStableDiffusionService
     {
+        IReadOnlyCollection<StableDiffusionModelSet> ModelSets { get; }
+
         /// <summary>
         /// Loads the model.
         /// </summary>

--- a/OnnxStack.StableDiffusion/Services/StableDiffusionService.cs
+++ b/OnnxStack.StableDiffusion/Services/StableDiffusionService.cs
@@ -43,6 +43,8 @@ namespace OnnxStack.StableDiffusion.Services
             _pipelines = pipelines.ToConcurrentDictionary(k => k.PipelineType, k => k);
         }
 
+        public IReadOnlyCollection<StableDiffusionModelSet> ModelSets => _configuration.ModelSets;
+
 
         /// <summary>
         /// Loads the model.


### PR DESCRIPTION
Workaround to fix run unit test fail.

StableDiffusionTests.cs(43,38): error CS1061: 'IStableDiffusionService' does not contain a definition for 'Models' and no accessible extension method 'Mode
ls' accepting a first argument of type 'IStableDiffusionService' could be found (are you missing a using directive or an assembly reference?) [C:\Users\kimi0\Desktop\ONNX\OnnxStack\OnnxStack.IntegrationTests\OnnxStack.In 
tegrationTests.csproj]