### PR TITLE
Example project fixes and readme additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 
+# Downloaded .onnx files
+onnx-models/
+
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/

--- a/OnnxStack.Console/Examples/StableDiffusionBatch.cs
+++ b/OnnxStack.Console/Examples/StableDiffusionBatch.cs
@@ -8,6 +8,8 @@ using SixLabors.ImageSharp;
 
 namespace OnnxStack.Console.Runner
 {
+    using StableDiffusion;
+
     public sealed class StableDiffusionBatch : IExampleRunner
     {
         private readonly string _outputDirectory;
@@ -56,6 +58,8 @@ namespace OnnxStack.Console.Runner
 
                 foreach (var model in _configuration.ModelSets)
                 {
+                    _setSchedulerTypeForPipeline();
+
                     OutputHelpers.WriteConsole($"Loading Model `{model.Name}`...", ConsoleColor.Green);
                     await _stableDiffusionService.LoadModelAsync(model);
 
@@ -76,6 +80,13 @@ namespace OnnxStack.Console.Runner
 
                     OutputHelpers.WriteConsole($"Unloading Model `{model.Name}`...", ConsoleColor.Green);
                     await _stableDiffusionService.UnloadModelAsync(model);
+                    continue;
+
+                    void _setSchedulerTypeForPipeline()
+                    {
+                        SchedulerType[] scheduleTypes = model.PipelineType.GetSchedulerTypes();
+                        schedulerOptions.SchedulerType = scheduleTypes.Length == 1 ? scheduleTypes[0] : scheduleTypes[Random.Shared.Next(scheduleTypes.Length)];
+                    }
                 }
             }
         }

--- a/OnnxStack.Console/README.md
+++ b/OnnxStack.Console/README.md
@@ -1,1 +1,39 @@
-Example - Console App
+# Example - Console App
+
+## Getting Started
+
+### 1.) Download the required `.onnx` models:
+
+
+  * https://huggingface.co/rocca/swin-ir-onnx
+    * This is the upscaler model.
+  * https://huggingface.co/runwayml/stable-diffusion-v1-5
+  * https://huggingface.co/softwareweaver/InstaFlow-0.9B-Olive-Onnx
+  * https://huggingface.co/SimianLuo/LCM_Dreamshaper_v7
+  * https://huggingface.co/softwareweaver/stable-diffusion-xl-base-1.0-Olive-Onnx
+
+Note: Ensure you run ```git lfs install``` before cloning the repository to ensure the models are downloaded correctly.
+
+
+### 2.) Update the paths in the `appsettings.json` within the `/OnnxStack.Console/` project:
+
+
+* Update the paths in `appsettings.json` to point to the downloaded models
+  * If the downloaded model repository does not contain a `Tokenizer` or `Tokenizer2` `.onnx` file, leave the path empty. 
+    * Note: When the path is empty, OnnxStack will use it's own 'built-in' tokenizer called `cliptokenizer.onnx`
+  * Example with empty path:
+```json    
+            {
+            "Type": "Tokenizer",
+            "OnnxModelPath": ""
+            }
+```
+
+
+### FAQ
+
+* **Q:** My `.GIF` is flashing, is it supposed to do this?
+* **A:** The `.GIF` area has been deprecated in favor of the 'video' features that are being added.  Please ignore this example for now.
+
+
+ 

--- a/OnnxStack.Console/README.md
+++ b/OnnxStack.Console/README.md
@@ -4,6 +4,9 @@
 
 ### 1.) Download the required `.onnx` models:
 
+**Method 1**
+
+  Download the required models from the following repositories:
 
   * https://huggingface.co/rocca/swin-ir-onnx
     * This is the upscaler model.
@@ -12,21 +15,62 @@
   * https://huggingface.co/SimianLuo/LCM_Dreamshaper_v7
   * https://huggingface.co/softwareweaver/stable-diffusion-xl-base-1.0-Olive-Onnx
 
-Note: Ensure you run ```git lfs install``` before cloning the repository to ensure the models are downloaded correctly.
+
+ Note: Ensure you run ```git lfs install``` before cloning the repository to ensure the models are downloaded correctly.
 
 
-### 2.) Update the paths in the `appsettings.json` within the `/OnnxStack.Console/` project:
+
+ 
+
+ 
+
+**Method 2**
+
+ Download Files
+
+Use the included 'download-models.bat' file to download the required models.
+* If your on mac or linux, you can open the `download-models.bat` file and run each command manually if you are unable to run the `.bat` file.
+  * The `download-models.bat` will create a `onnx-models/` folder in current directory. Then it will download the required models into the `onnx-models/` folder.
+  * If you are unable to run the `.bat` file or have issues, you can open the `download-models.bat` file and run each command manually.
+  * The `.bat` file will not attempt to 're-download' or continue if the file already exists. If you need to re-download the models, delete the `onnx-models/` folder and run the `.bat` file again.
 
 
-* Update the paths in `appsettings.json` to point to the downloaded models
+### 2.) If necessary, switch to the correct Stable Diffusion 1.5 branch
+
+**Stable Diffusion 1.5 - Get the .onnx files after download.**
+
+* After you download the `Stable Diffusion 1.5` model at: https://huggingface.co/runwayml/stable-diffusion-v1-5, check to see if any of the folders contain `.onnx` files.
+  * If none contain `.onnx` files, you will need to switch to the `.onnx` branch.
+    * If you have already checked out the `onnx` branch and have the `.onnx` files from the `Stable Diffusion 1.5` repository, you can skip this step.
+
+
+We need to switch to the `onnx` branch to get the `.onnx` files.  
+You can do this anyway you would like, or just run the following commands:
+* Open a new command prompt in `onnx-models/stable-diffusion-v1-5/`
+```bash
+git fetch origin
+git checkout origin/onnx
+```
+_It might take some time to switch branches and download all of the `.onnx` files pending your internet speed._
+ 
+
+
+### 3.) Update the paths in the `appsettings.json` within the `/OnnxStack.Console/` project:
+
+
+* Update the paths in `appsettings.json` to point to the downloaded models.  Update all the paths to point to the correct location of the downloaded models.
   * If the downloaded model repository does not contain a `Tokenizer` or `Tokenizer2` `.onnx` file, leave the path empty. 
-    * Note: When the path is empty, OnnxStack will use it's own 'built-in' tokenizer called `cliptokenizer.onnx`
+    * Note: When the path is empty, OnnxStack will use it's own 'built-in' _default_ tokenizer called `cliptokenizer.onnx`
   * Example with empty path:
 ```json    
-            {
-            "Type": "Tokenizer",
-            "OnnxModelPath": ""
-            }
+  {
+  "Type": "Tokenizer",
+  "OnnxModelPath": ""
+  },
+  {
+  "Type": "Tokenizer2",
+  "OnnxModelPath": ""
+  }
 ```
 
 

--- a/OnnxStack.Console/README.md
+++ b/OnnxStack.Console/README.md
@@ -1,0 +1,1 @@
+Example - Console App

--- a/OnnxStack.Console/README.md
+++ b/OnnxStack.Console/README.md
@@ -28,8 +28,14 @@
 
  Download Files
 
-Use the included 'download-models.bat' file to download the required models.
-* If your on mac or linux, you can open the `download-models.bat` file and run each command manually if you are unable to run the `.bat` file.
+**Experimental script** 
+
+_Note: The `download-models.bat` file is not smart enough to know if you have already downloaded the models. If you need to re-download the models, please run the commands manually within `git` to pull the latest changes from the target repository._
+
+> If your on mac or linux, you can open the `download-models.bat` file and run each command manually if you are unable to run the `.bat` file.
+
+Use the included `download-models.bat` file to download the required models.
+
   * The `download-models.bat` will create a `onnx-models/` folder in current directory. Then it will download the required models into the `onnx-models/` folder.
   * If you are unable to run the `.bat` file or have issues, you can open the `download-models.bat` file and run each command manually.
   * The `.bat` file will not attempt to 're-download' or continue if the file already exists. If you need to re-download the models, delete the `onnx-models/` folder and run the `.bat` file again.
@@ -78,6 +84,11 @@ _It might take some time to switch branches and download all of the `.onnx` file
 
 * **Q:** My `.GIF` is flashing, is it supposed to do this?
 * **A:** The `.GIF` area has been deprecated in favor of the 'video' features that are being added.  Please ignore this example for now.
+
+* **Q:** I am getting an error: `138 are out of bounds or can not be read in full`
+* **A:**  usually means the model is corrupt or has not been fully downloaded, make sure if you clone the repo you have git LFS installed, or you will just get small pointer files not the large GB files
+
+
 
 
  

--- a/OnnxStack.Console/appsettings.json
+++ b/OnnxStack.Console/appsettings.json
@@ -205,7 +205,7 @@
         "ExecutionProvider": "DirectML",
         "ModelConfigurations": [
           {
-            "Type": "Unet",
+            "Type": "Upscaler",
             "OnnxModelPath": "D:\\Repositories\\upscaler\\SwinIR\\003_realSR_BSRGAN_DFO_s64w8_SwinIR-M_x4_GAN.onnx"
           }
         ]

--- a/OnnxStack.Console/download-models.bat
+++ b/OnnxStack.Console/download-models.bat
@@ -1,0 +1,9 @@
+mkdir onnx-models
+cd onnx-models
+git lfs install
+git clone https://huggingface.co/rocca/swin-ir-onnx
+git clone https://huggingface.co/runwayml/stable-diffusion-v1-5
+git clone https://huggingface.co/softwareweaver/InstaFlow-0.9B-Olive-Onnx
+git clone https://huggingface.co/SimianLuo/LCM_Dreamshaper_v7
+git clone https://huggingface.co/softwareweaver/stable-diffusion-xl-base-1.0-Olive-Onnx
+


### PR DESCRIPTION
Changes:

* Fixed the type from `Unet` to `Upscalers` in the example `appsettings.json` folder
* Fixed example 2 in the console app
* Added readme instructions for 'how to get started' with the example app
* Added an experimental script to auto-download the required models for the example project to an `onnx-models/` directory 
    *    Also added this folder `onnx-models/` to git ignore
* Added short FAQ section with some common configuration errors