### PR TITLE
chore: Examples add schedulerOptions.Width and Height ; Fix Batchinde…

### DIFF
--- a/OnnxStack.Console/Examples/StableDiffusionBatch.cs
+++ b/OnnxStack.Console/Examples/StableDiffusionBatch.cs
@@ -63,6 +63,9 @@ namespace OnnxStack.Console.Runner
                     OutputHelpers.WriteConsole($"Loading Model `{model.Name}`...", ConsoleColor.Green);
                     await _stableDiffusionService.LoadModelAsync(model);
 
+                    schedulerOptions.Width = model.SampleSize;
+                    schedulerOptions.Height = model.SampleSize;
+
                     var batchIndex = 0;
                     var callback = (DiffusionProgress progress) =>
                     {
@@ -70,7 +73,7 @@ namespace OnnxStack.Console.Runner
                         OutputHelpers.WriteConsole($"Image: {progress.BatchValue}/{progress.BatchMax} - Step: {progress.StepValue}/{progress.StepMax}", ConsoleColor.Cyan);
                     };
 
-                    await foreach (var result in _stableDiffusionService.GenerateBatchAsync(new ModelOptions(model), promptOptions, schedulerOptions, batchOptions, default))
+                    await foreach (var result in _stableDiffusionService.GenerateBatchAsync(new ModelOptions(model), promptOptions, schedulerOptions, batchOptions, callback))
                     {
                         var outputFilename = Path.Combine(_outputDirectory, $"{batchIndex}_{result.SchedulerOptions.Seed}.png");
                         var image = result.ImageResult.ToImage();

--- a/OnnxStack.Console/Examples/StableDiffusionExample.cs
+++ b/OnnxStack.Console/Examples/StableDiffusionExample.cs
@@ -54,6 +54,9 @@ namespace OnnxStack.Console.Runner
                     OutputHelpers.WriteConsole($"Loading Model `{model.Name}`...", ConsoleColor.Green);
                     await _stableDiffusionService.LoadModelAsync(model);
 
+                    schedulerOptions.Width = model.SampleSize;
+                    schedulerOptions.Height = model.SampleSize;
+                    
                     foreach (var schedulerType in model.PipelineType.GetSchedulerTypes())
                     {
                         schedulerOptions.SchedulerType = schedulerType;


### PR DESCRIPTION
Hi,

When ruining SDXL, image always 512x512 not 1024x1024, and image will be overwrite when run batch example
These are some little change in Examples.

* Examples/StableDiffusionBatch.cs add schedulerOptions.Width and Height and Fix Batchindex always be 0.
* Examples/StableDiffusionExample.cs.cs add schedulerOptions.Width and Height.

Thanks.