### PR TITLE
Support for low memory devices

### DIFF
--- a/OnnxStack.Core/Model/OnnxModelSession.cs
+++ b/OnnxStack.Core/Model/OnnxModelSession.cs
@@ -67,14 +67,15 @@ namespace OnnxStack.Core.Model
         /// Unloads the model session.
         /// </summary>
         /// <returns></returns>
-        public Task UnloadAsync()
+        public async Task UnloadAsync()
         {
+            await Task.Yield();
             if (_session is not null)
             {
-                _metadata = null;
                 _session.Dispose();
+                _metadata = null;
+                _session = null;
             }
-            return Task.CompletedTask;
         }
 
 

--- a/OnnxStack.StableDiffusion/Config/PipelineOptions.cs
+++ b/OnnxStack.StableDiffusion/Config/PipelineOptions.cs
@@ -1,0 +1,7 @@
+﻿using OnnxStack.StableDiffusion.Enums;
+
+namespace OnnxStack.StableDiffusion.Config
+{
+    public record PipelineOptions(string Name, MemoryModeType MemoryMode);
+
+}

--- a/OnnxStack.StableDiffusion/Config/StableDiffusionModelSet.cs
+++ b/OnnxStack.StableDiffusion/Config/StableDiffusionModelSet.cs
@@ -14,7 +14,7 @@ namespace OnnxStack.StableDiffusion.Config
         public int SampleSize { get; set; } = 512;
         public DiffuserPipelineType PipelineType { get; set; }
         public List<DiffuserType> Diffusers { get; set; } = new List<DiffuserType>();
-
+        public MemoryModeType MemoryMode { get; set; }
         public int DeviceId { get; set; }
         public int InterOpNumThreads { get; set; }
         public int IntraOpNumThreads { get; set; }

--- a/OnnxStack.StableDiffusion/Diffusers/InstaFlow/ControlNetDiffuser.cs
+++ b/OnnxStack.StableDiffusion/Diffusers/InstaFlow/ControlNetDiffuser.cs
@@ -30,8 +30,8 @@ namespace OnnxStack.StableDiffusion.Diffusers.InstaFlow
         /// <param name="vaeDecoder">The vae decoder.</param>
         /// <param name="vaeEncoder">The vae encoder.</param>
         /// <param name="logger">The logger.</param>
-        public ControlNetDiffuser(ControlNetModel controlNet, UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, ILogger logger = default)
-            : base(unet, vaeDecoder, vaeEncoder, logger)
+        public ControlNetDiffuser(ControlNetModel controlNet, UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, MemoryModeType memoryMode, ILogger logger = default)
+            : base(unet, vaeDecoder, vaeEncoder, memoryMode, logger)
         {
             _controlNet = controlNet;
         }
@@ -145,6 +145,13 @@ namespace OnnxStack.StableDiffusion.Diffusers.InstaFlow
 
                     ReportProgress(progressCallback, step, timesteps.Count, latents);
                     _logger?.LogEnd($"Step {step}/{timesteps.Count}", stepTime);
+                }
+
+                // Unload if required
+                if (_memoryMode != MemoryModeType.Maximum)
+                {
+                    await _unet.UnloadAsync();
+                    await _controlNet.UnloadAsync();
                 }
 
                 // Decode Latents

--- a/OnnxStack.StableDiffusion/Diffusers/InstaFlow/InstaFlowDiffuser.cs
+++ b/OnnxStack.StableDiffusion/Diffusers/InstaFlow/InstaFlowDiffuser.cs
@@ -26,8 +26,8 @@ namespace OnnxStack.StableDiffusion.Diffusers.InstaFlow
         /// <param name="vaeDecoder">The vae decoder.</param>
         /// <param name="vaeEncoder">The vae encoder.</param>
         /// <param name="logger">The logger.</param>
-        public InstaFlowDiffuser(UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, ILogger logger = default)
-            : base(unet, vaeDecoder, vaeEncoder, logger) { }
+        public InstaFlowDiffuser(UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, MemoryModeType memoryMode, ILogger logger = default)
+            : base(unet, vaeDecoder, vaeEncoder, memoryMode, logger) { }
 
         /// <summary>
         /// Gets the type of the pipeline.
@@ -105,6 +105,10 @@ namespace OnnxStack.StableDiffusion.Diffusers.InstaFlow
                     ReportProgress(progressCallback, step, timesteps.Count, latents);
                     _logger?.LogEnd($"Step {step}/{timesteps.Count}", stepTime);
                 }
+
+                // Unload if required
+                if (_memoryMode != MemoryModeType.Maximum)
+                    await _unet.UnloadAsync();
 
                 // Decode Latents
                 return await DecodeLatentsAsync(promptOptions, schedulerOptions, latents);

--- a/OnnxStack.StableDiffusion/Diffusers/InstaFlow/TextDiffuser.cs
+++ b/OnnxStack.StableDiffusion/Diffusers/InstaFlow/TextDiffuser.cs
@@ -20,8 +20,8 @@ namespace OnnxStack.StableDiffusion.Diffusers.InstaFlow
         /// <param name="vaeDecoder">The vae decoder.</param>
         /// <param name="vaeEncoder">The vae encoder.</param>
         /// <param name="logger">The logger.</param>
-        public TextDiffuser(UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, ILogger logger = default)
-            : base(unet, vaeDecoder, vaeEncoder, logger) { }
+        public TextDiffuser(UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, MemoryModeType memoryMode, ILogger logger = default)
+            : base(unet, vaeDecoder, vaeEncoder, memoryMode, logger) { }
 
 
         /// <summary>

--- a/OnnxStack.StableDiffusion/Diffusers/LatentConsistency/ControlNetDiffuser.cs
+++ b/OnnxStack.StableDiffusion/Diffusers/LatentConsistency/ControlNetDiffuser.cs
@@ -29,8 +29,8 @@ namespace OnnxStack.StableDiffusion.Diffusers.LatentConsistency
         /// <param name="vaeDecoder">The vae decoder.</param>
         /// <param name="vaeEncoder">The vae encoder.</param>
         /// <param name="logger">The logger.</param>
-        public ControlNetDiffuser(ControlNetModel controlNet, UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, ILogger logger = default)
-            : base(unet, vaeDecoder, vaeEncoder, logger)
+        public ControlNetDiffuser(ControlNetModel controlNet, UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, MemoryModeType memoryMode, ILogger logger = default)
+            : base(unet, vaeDecoder, vaeEncoder, memoryMode, logger)
         {
             _controlNet = controlNet;
         }
@@ -142,6 +142,13 @@ namespace OnnxStack.StableDiffusion.Diffusers.LatentConsistency
 
                     ReportProgress(progressCallback, step, timesteps.Count, latents);
                     _logger?.LogEnd($"Step {step}/{timesteps.Count}", stepTime);
+                }
+
+                // Unload if required
+                if (_memoryMode != MemoryModeType.Maximum)
+                {
+                    await _unet.UnloadAsync();
+                    await _controlNet.UnloadAsync();
                 }
 
                 // Decode Latents

--- a/OnnxStack.StableDiffusion/Diffusers/LatentConsistency/ImageDiffuser.cs
+++ b/OnnxStack.StableDiffusion/Diffusers/LatentConsistency/ImageDiffuser.cs
@@ -26,8 +26,8 @@ namespace OnnxStack.StableDiffusion.Diffusers.LatentConsistency
         /// <param name="vaeDecoder">The vae decoder.</param>
         /// <param name="vaeEncoder">The vae encoder.</param>
         /// <param name="logger">The logger.</param>
-        public ImageDiffuser(UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, ILogger logger = default)
-            : base(unet, vaeDecoder, vaeEncoder, logger) { }
+        public ImageDiffuser(UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, MemoryModeType memoryMode, ILogger logger = default)
+            : base(unet, vaeDecoder, vaeEncoder, memoryMode, logger) { }
 
 
         /// <summary>
@@ -70,6 +70,10 @@ namespace OnnxStack.StableDiffusion.Diffusers.LatentConsistency
                 var results = await _vaeEncoder.RunInferenceAsync(inferenceParameters);
                 using (var result = results.First())
                 {
+                    // Unload if required
+                    if (_memoryMode != MemoryModeType.Maximum)
+                        await _vaeEncoder.UnloadAsync();
+
                     var outputResult = result.ToDenseTensor();
                     var scaledSample = outputResult.MultiplyBy(_vaeEncoder.ScaleFactor);
                     return scheduler.AddNoise(scaledSample, scheduler.CreateRandomSample(scaledSample.Dimensions), timesteps);

--- a/OnnxStack.StableDiffusion/Diffusers/LatentConsistency/LatentConsistencyDiffuser.cs
+++ b/OnnxStack.StableDiffusion/Diffusers/LatentConsistency/LatentConsistencyDiffuser.cs
@@ -26,8 +26,8 @@ namespace OnnxStack.StableDiffusion.Diffusers.LatentConsistency
         /// <param name="vaeDecoder">The vae decoder.</param>
         /// <param name="vaeEncoder">The vae encoder.</param>
         /// <param name="logger">The logger.</param>
-        public LatentConsistencyDiffuser(UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, ILogger logger = default)
-            : base(unet, vaeDecoder, vaeEncoder, logger) { }
+        public LatentConsistencyDiffuser(UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, MemoryModeType memoryMode, ILogger logger = default)
+            : base(unet, vaeDecoder, vaeEncoder, memoryMode, logger) { }
 
 
         /// <summary>
@@ -105,6 +105,10 @@ namespace OnnxStack.StableDiffusion.Diffusers.LatentConsistency
                     ReportProgress(progressCallback, step, timesteps.Count, latents);
                     _logger?.LogEnd($"Step {step}/{timesteps.Count}", stepTime);
                 }
+
+                // Unload if required
+                if (_memoryMode != MemoryModeType.Maximum)
+                    await _unet.UnloadAsync();
 
                 // Decode Latents
                 return await DecodeLatentsAsync(promptOptions, schedulerOptions, denoised);

--- a/OnnxStack.StableDiffusion/Diffusers/LatentConsistency/TextDiffuser.cs
+++ b/OnnxStack.StableDiffusion/Diffusers/LatentConsistency/TextDiffuser.cs
@@ -20,8 +20,8 @@ namespace OnnxStack.StableDiffusion.Diffusers.LatentConsistency
         /// <param name="vaeDecoder">The vae decoder.</param>
         /// <param name="vaeEncoder">The vae encoder.</param>
         /// <param name="logger">The logger.</param>
-        public TextDiffuser(UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, ILogger logger = default)
-            : base(unet, vaeDecoder, vaeEncoder, logger) { }
+        public TextDiffuser(UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, MemoryModeType memoryMode, ILogger logger = default)
+            : base(unet, vaeDecoder, vaeEncoder, memoryMode, logger) { }
 
 
         /// <summary>

--- a/OnnxStack.StableDiffusion/Diffusers/LatentConsistencyXL/ControlNetDiffuser.cs
+++ b/OnnxStack.StableDiffusion/Diffusers/LatentConsistencyXL/ControlNetDiffuser.cs
@@ -29,8 +29,8 @@ namespace OnnxStack.StableDiffusion.Diffusers.LatentConsistencyXL
         /// <param name="vaeDecoder">The vae decoder.</param>
         /// <param name="vaeEncoder">The vae encoder.</param>
         /// <param name="logger">The logger.</param>
-        public ControlNetDiffuser(ControlNetModel controlNet, UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, ILogger logger = default)
-            : base(unet, vaeDecoder, vaeEncoder, logger)
+        public ControlNetDiffuser(ControlNetModel controlNet, UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, MemoryModeType memoryMode, ILogger logger = default)
+            : base(unet, vaeDecoder, vaeEncoder, memoryMode, logger)
         {
             _controlNet = controlNet;
         }
@@ -147,6 +147,13 @@ namespace OnnxStack.StableDiffusion.Diffusers.LatentConsistencyXL
 
                     ReportProgress(progressCallback, step, timesteps.Count, latents);
                     _logger?.LogEnd($"Step {step}/{timesteps.Count}", stepTime);
+                }
+
+                // Unload if required
+                if (_memoryMode != MemoryModeType.Maximum)
+                {
+                    await _unet.UnloadAsync();
+                    await _controlNet.UnloadAsync();
                 }
 
                 // Decode Latents

--- a/OnnxStack.StableDiffusion/Diffusers/LatentConsistencyXL/ControlNetImageDiffuser.cs
+++ b/OnnxStack.StableDiffusion/Diffusers/LatentConsistencyXL/ControlNetImageDiffuser.cs
@@ -27,8 +27,8 @@ namespace OnnxStack.StableDiffusion.Diffusers.LatentConsistencyXL
         /// <param name="vaeDecoder">The vae decoder.</param>
         /// <param name="vaeEncoder">The vae encoder.</param>
         /// <param name="logger">The logger.</param>
-        public ControlNetImageDiffuser(ControlNetModel controlNet, UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, ILogger logger = default)
-            : base(controlNet, unet, vaeDecoder, vaeEncoder, logger) { }
+        public ControlNetImageDiffuser(ControlNetModel controlNet, UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, MemoryModeType memoryMode, ILogger logger = default)
+            : base(controlNet, unet, vaeDecoder, vaeEncoder, memoryMode, logger) { }
 
 
         /// <summary>
@@ -71,6 +71,10 @@ namespace OnnxStack.StableDiffusion.Diffusers.LatentConsistencyXL
                 var results = await _vaeEncoder.RunInferenceAsync(inferenceParameters);
                 using (var result = results.First())
                 {
+                    // Unload if required
+                    if (_memoryMode != MemoryModeType.Maximum)
+                        await _vaeEncoder.UnloadAsync();
+
                     var outputResult = result.ToDenseTensor();
                     var scaledSample = outputResult.MultiplyBy(_vaeEncoder.ScaleFactor);
                     return scheduler.AddNoise(scaledSample, scheduler.CreateRandomSample(scaledSample.Dimensions), timesteps);

--- a/OnnxStack.StableDiffusion/Diffusers/LatentConsistencyXL/ImageDiffuser.cs
+++ b/OnnxStack.StableDiffusion/Diffusers/LatentConsistencyXL/ImageDiffuser.cs
@@ -27,8 +27,8 @@ namespace OnnxStack.StableDiffusion.Diffusers.LatentConsistencyXL
         /// <param name="vaeDecoder">The vae decoder.</param>
         /// <param name="vaeEncoder">The vae encoder.</param>
         /// <param name="logger">The logger.</param>
-        public ImageDiffuser(UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, ILogger logger = default)
-            : base(unet, vaeDecoder, vaeEncoder, logger) { }
+        public ImageDiffuser(UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, MemoryModeType memoryMode, ILogger logger = default)
+            : base(unet, vaeDecoder, vaeEncoder, memoryMode, logger) { }
 
 
         /// <summary>
@@ -72,6 +72,10 @@ namespace OnnxStack.StableDiffusion.Diffusers.LatentConsistencyXL
                 var results = await _vaeEncoder.RunInferenceAsync(inferenceParameters);
                 using (var result = results.First())
                 {
+                    // Unload if required
+                    if (_memoryMode != MemoryModeType.Maximum)
+                        await _vaeEncoder.UnloadAsync();
+
                     var outputResult = result.ToDenseTensor();
                     var scaledSample = outputResult.MultiplyBy(_vaeEncoder.ScaleFactor);
                     return scheduler.AddNoise(scaledSample, scheduler.CreateRandomSample(scaledSample.Dimensions), timesteps);

--- a/OnnxStack.StableDiffusion/Diffusers/LatentConsistencyXL/InpaintLegacyDiffuser.cs
+++ b/OnnxStack.StableDiffusion/Diffusers/LatentConsistencyXL/InpaintLegacyDiffuser.cs
@@ -29,8 +29,8 @@ namespace OnnxStack.StableDiffusion.Diffusers.LatentConsistencyXL
         /// <param name="vaeDecoder">The vae decoder.</param>
         /// <param name="vaeEncoder">The vae encoder.</param>
         /// <param name="logger">The logger.</param>
-        public InpaintLegacyDiffuser(UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, ILogger logger = default)
-            : base(unet, vaeDecoder, vaeEncoder, logger) { }
+        public InpaintLegacyDiffuser(UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, MemoryModeType memoryMode, ILogger logger = default)
+            : base(unet, vaeDecoder, vaeEncoder, memoryMode, logger) { }
 
 
         /// <summary>
@@ -123,6 +123,10 @@ namespace OnnxStack.StableDiffusion.Diffusers.LatentConsistencyXL
                     _logger?.LogEnd($"Step {step}/{timesteps.Count}", stepTime);
                 }
 
+                // Unload if required
+                if (_memoryMode != MemoryModeType.Maximum)
+                    await _unet.UnloadAsync();
+
                 // Decode Latents
                 return await DecodeLatentsAsync(promptOptions, schedulerOptions, latents);
             }
@@ -163,6 +167,10 @@ namespace OnnxStack.StableDiffusion.Diffusers.LatentConsistencyXL
                 var results = await _vaeEncoder.RunInferenceAsync(inferenceParameters);
                 using (var result = results.First())
                 {
+                    // Unload if required
+                    if (_memoryMode != MemoryModeType.Maximum)
+                        await _vaeEncoder.UnloadAsync();
+
                     var outputResult = result.ToDenseTensor();
                     var scaledSample = outputResult.MultiplyBy(_vaeEncoder.ScaleFactor);
                     return scaledSample;

--- a/OnnxStack.StableDiffusion/Diffusers/LatentConsistencyXL/LatentConsistencyXLDiffuser.cs
+++ b/OnnxStack.StableDiffusion/Diffusers/LatentConsistencyXL/LatentConsistencyXLDiffuser.cs
@@ -19,8 +19,8 @@ namespace OnnxStack.StableDiffusion.Diffusers.LatentConsistencyXL
         /// <param name="vaeDecoder">The vae decoder.</param>
         /// <param name="vaeEncoder">The vae encoder.</param>
         /// <param name="logger">The logger.</param>
-        protected LatentConsistencyXLDiffuser(UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, ILogger logger = default)
-            : base(unet, vaeDecoder, vaeEncoder, logger) { }
+        protected LatentConsistencyXLDiffuser(UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, MemoryModeType memoryMode, ILogger logger = default)
+            : base(unet, vaeDecoder, vaeEncoder, memoryMode, logger) { }
 
 
         /// <summary>

--- a/OnnxStack.StableDiffusion/Diffusers/LatentConsistencyXL/TextDiffuser.cs
+++ b/OnnxStack.StableDiffusion/Diffusers/LatentConsistencyXL/TextDiffuser.cs
@@ -20,8 +20,8 @@ namespace OnnxStack.StableDiffusion.Diffusers.LatentConsistencyXL
         /// <param name="vaeDecoder">The vae decoder.</param>
         /// <param name="vaeEncoder">The vae encoder.</param>
         /// <param name="logger">The logger.</param>
-        public TextDiffuser(UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, ILogger logger = default)
-            : base(unet, vaeDecoder, vaeEncoder, logger) { }
+        public TextDiffuser(UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, MemoryModeType memoryMode, ILogger logger = default)
+            : base(unet, vaeDecoder, vaeEncoder, memoryMode, logger) { }
 
 
         /// <summary>

--- a/OnnxStack.StableDiffusion/Diffusers/StableDiffusion/ControlNetDiffuser.cs
+++ b/OnnxStack.StableDiffusion/Diffusers/StableDiffusion/ControlNetDiffuser.cs
@@ -29,8 +29,8 @@ namespace OnnxStack.StableDiffusion.Diffusers.StableDiffusion
         /// <param name="vaeDecoder">The vae decoder.</param>
         /// <param name="vaeEncoder">The vae encoder.</param>
         /// <param name="logger">The logger.</param>
-        public ControlNetDiffuser(ControlNetModel controlNet, UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, ILogger logger = default)
-            : base(unet, vaeDecoder, vaeEncoder, logger)
+        public ControlNetDiffuser(ControlNetModel controlNet, UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, MemoryModeType memoryMode, ILogger logger = default)
+            : base(unet, vaeDecoder, vaeEncoder, memoryMode, logger)
         {
             _controlNet = controlNet;
         }
@@ -138,6 +138,13 @@ namespace OnnxStack.StableDiffusion.Diffusers.StableDiffusion
 
                     ReportProgress(progressCallback, step, timesteps.Count, latents);
                     _logger?.LogEnd($"Step {step}/{timesteps.Count}", stepTime);
+                }
+
+                // Unload if required
+                if (_memoryMode != MemoryModeType.Maximum)
+                {
+                    await _unet.UnloadAsync();
+                    await _controlNet.UnloadAsync();
                 }
 
                 // Decode Latents

--- a/OnnxStack.StableDiffusion/Diffusers/StableDiffusion/ControlNetImageDiffuser.cs
+++ b/OnnxStack.StableDiffusion/Diffusers/StableDiffusion/ControlNetImageDiffuser.cs
@@ -27,8 +27,8 @@ namespace OnnxStack.StableDiffusion.Diffusers.StableDiffusion
         /// <param name="vaeDecoder">The vae decoder.</param>
         /// <param name="vaeEncoder">The vae encoder.</param>
         /// <param name="logger">The logger.</param>
-        public ControlNetImageDiffuser(ControlNetModel controlNet, UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, ILogger logger = default)
-            : base(controlNet, unet, vaeDecoder, vaeEncoder, logger) { }
+        public ControlNetImageDiffuser(ControlNetModel controlNet, UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, MemoryModeType memoryMode, ILogger logger = default)
+            : base(controlNet, unet, vaeDecoder, vaeEncoder, memoryMode, logger) { }
 
 
         /// <summary>
@@ -71,6 +71,10 @@ namespace OnnxStack.StableDiffusion.Diffusers.StableDiffusion
                 var results = await _vaeEncoder.RunInferenceAsync(inferenceParameters);
                 using (var result = results.First())
                 {
+                    // Unload if required
+                    if (_memoryMode != MemoryModeType.Maximum)
+                        await _vaeEncoder.UnloadAsync();
+
                     var outputResult = result.ToDenseTensor();
                     var scaledSample = outputResult.MultiplyBy(_vaeEncoder.ScaleFactor);
                     return scheduler.AddNoise(scaledSample, scheduler.CreateRandomSample(scaledSample.Dimensions), timesteps);

--- a/OnnxStack.StableDiffusion/Diffusers/StableDiffusion/ImageDiffuser.cs
+++ b/OnnxStack.StableDiffusion/Diffusers/StableDiffusion/ImageDiffuser.cs
@@ -26,8 +26,8 @@ namespace OnnxStack.StableDiffusion.Diffusers.StableDiffusion
         /// <param name="vaeDecoder">The vae decoder.</param>
         /// <param name="vaeEncoder">The vae encoder.</param>
         /// <param name="logger">The logger.</param>
-        public ImageDiffuser(UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, ILogger logger = default)
-            : base(unet, vaeDecoder, vaeEncoder, logger) { }
+        public ImageDiffuser(UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, MemoryModeType memoryMode, ILogger logger = default)
+            : base(unet, vaeDecoder, vaeEncoder, memoryMode, logger) { }
 
 
         /// <summary>
@@ -71,6 +71,10 @@ namespace OnnxStack.StableDiffusion.Diffusers.StableDiffusion
                 var results = await _vaeEncoder.RunInferenceAsync(inferenceParameters);
                 using (var result = results.First())
                 {
+                    // Unload if required
+                    if (_memoryMode != MemoryModeType.Maximum)
+                        await _vaeEncoder.UnloadAsync();
+
                     var outputResult = result.ToDenseTensor();
                     var scaledSample = outputResult.MultiplyBy(_vaeEncoder.ScaleFactor);
                     return scheduler.AddNoise(scaledSample, scheduler.CreateRandomSample(scaledSample.Dimensions), timesteps);

--- a/OnnxStack.StableDiffusion/Diffusers/StableDiffusion/StableDiffusionDiffuser.cs
+++ b/OnnxStack.StableDiffusion/Diffusers/StableDiffusion/StableDiffusionDiffuser.cs
@@ -25,8 +25,8 @@ namespace OnnxStack.StableDiffusion.Diffusers.StableDiffusion
         /// <param name="vaeDecoder">The vae decoder.</param>
         /// <param name="vaeEncoder">The vae encoder.</param>
         /// <param name="logger">The logger.</param>
-        public StableDiffusionDiffuser(UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, ILogger logger = default)
-            : base(unet, vaeDecoder, vaeEncoder, logger) { }
+        public StableDiffusionDiffuser(UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, MemoryModeType memoryMode, ILogger logger = default)
+            : base(unet, vaeDecoder, vaeEncoder, memoryMode, logger) { }
 
 
         /// <summary>
@@ -95,9 +95,14 @@ namespace OnnxStack.StableDiffusion.Diffusers.StableDiffusion
                         }
                     }
 
-                     ReportProgress(progressCallback, step, timesteps.Count, latents);
+                    ReportProgress(progressCallback, step, timesteps.Count, latents);
                     _logger?.LogEnd($"Step {step}/{timesteps.Count}", stepTime);
                 }
+
+                // Unload if required
+                if (_memoryMode != MemoryModeType.Maximum)
+                    await _unet.UnloadAsync();
+
 
                 // Decode Latents
                 return await DecodeLatentsAsync(promptOptions, schedulerOptions, latents);

--- a/OnnxStack.StableDiffusion/Diffusers/StableDiffusion/TextDiffuser.cs
+++ b/OnnxStack.StableDiffusion/Diffusers/StableDiffusion/TextDiffuser.cs
@@ -20,8 +20,8 @@ namespace OnnxStack.StableDiffusion.Diffusers.StableDiffusion
         /// <param name="vaeDecoder">The vae decoder.</param>
         /// <param name="vaeEncoder">The vae encoder.</param>
         /// <param name="logger">The logger.</param>
-        public TextDiffuser(UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, ILogger logger = default)
-            : base(unet, vaeDecoder, vaeEncoder, logger) { }
+        public TextDiffuser(UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, MemoryModeType memoryMode, ILogger logger = default)
+            : base(unet, vaeDecoder, vaeEncoder, memoryMode, logger) { }
 
 
         /// <summary>

--- a/OnnxStack.StableDiffusion/Diffusers/StableDiffusionXL/ControlNetDiffuser.cs
+++ b/OnnxStack.StableDiffusion/Diffusers/StableDiffusionXL/ControlNetDiffuser.cs
@@ -29,8 +29,8 @@ namespace OnnxStack.StableDiffusion.Diffusers.StableDiffusionXL
         /// <param name="vaeDecoder">The vae decoder.</param>
         /// <param name="vaeEncoder">The vae encoder.</param>
         /// <param name="logger">The logger.</param>
-        public ControlNetDiffuser( ControlNetModel controlNet, UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, ILogger logger = default)
-            : base(unet, vaeDecoder, vaeEncoder, logger)
+        public ControlNetDiffuser( ControlNetModel controlNet, UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, MemoryModeType memoryMode, ILogger logger = default)
+            : base(unet, vaeDecoder, vaeEncoder, memoryMode, logger)
         {
             _controlNet = controlNet;
         }
@@ -148,6 +148,13 @@ namespace OnnxStack.StableDiffusion.Diffusers.StableDiffusionXL
 
                     ReportProgress(progressCallback, step, timesteps.Count, latents);
                     _logger?.LogEnd($"Step {step}/{timesteps.Count}", stepTime);
+                }
+
+                // Unload if required
+                if (_memoryMode != MemoryModeType.Maximum)
+                {
+                    await _unet.UnloadAsync();
+                    await _controlNet.UnloadAsync();
                 }
 
                 // Decode Latents

--- a/OnnxStack.StableDiffusion/Diffusers/StableDiffusionXL/ControlNetImageDiffuser.cs
+++ b/OnnxStack.StableDiffusion/Diffusers/StableDiffusionXL/ControlNetImageDiffuser.cs
@@ -27,8 +27,8 @@ namespace OnnxStack.StableDiffusion.Diffusers.StableDiffusionXL
         /// <param name="vaeDecoder">The vae decoder.</param>
         /// <param name="vaeEncoder">The vae encoder.</param>
         /// <param name="logger">The logger.</param>
-        public ControlNetImageDiffuser(ControlNetModel controlNet, UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, ILogger logger = default)
-            : base(controlNet, unet, vaeDecoder, vaeEncoder, logger) { }
+        public ControlNetImageDiffuser(ControlNetModel controlNet, UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, MemoryModeType memoryMode, ILogger logger = default)
+            : base(controlNet, unet, vaeDecoder, vaeEncoder, memoryMode, logger) { }
 
 
         /// <summary>
@@ -74,6 +74,10 @@ namespace OnnxStack.StableDiffusion.Diffusers.StableDiffusionXL
                 var results = await _vaeEncoder.RunInferenceAsync(inferenceParameters);
                 using (var result = results.First())
                 {
+                    // Unload if required
+                    if (_memoryMode != MemoryModeType.Maximum)
+                        await _vaeEncoder.UnloadAsync();
+
                     var outputResult = result.ToDenseTensor();
                     var scaledSample = outputResult.MultiplyBy(_vaeEncoder.ScaleFactor);
                     return scheduler.AddNoise(scaledSample, scheduler.CreateRandomSample(scaledSample.Dimensions), timesteps);

--- a/OnnxStack.StableDiffusion/Diffusers/StableDiffusionXL/ImageDiffuser.cs
+++ b/OnnxStack.StableDiffusion/Diffusers/StableDiffusionXL/ImageDiffuser.cs
@@ -26,8 +26,8 @@ namespace OnnxStack.StableDiffusion.Diffusers.StableDiffusionXL
         /// <param name="vaeDecoder"></param>
         /// <param name="vaeEncoder"></param>
         /// <param name="logger"></param>
-        public ImageDiffuser(UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, ILogger logger = default)
-            : base(unet, vaeDecoder, vaeEncoder, logger) { }
+        public ImageDiffuser(UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, MemoryModeType memoryMode, ILogger logger = default)
+            : base(unet, vaeDecoder, vaeEncoder, memoryMode, logger) { }
 
 
         /// <summary>
@@ -74,6 +74,10 @@ namespace OnnxStack.StableDiffusion.Diffusers.StableDiffusionXL
                 var results = await _vaeEncoder.RunInferenceAsync(inferenceParameters);
                 using (var result = results.First())
                 {
+                    // Unload if required
+                    if (_memoryMode != MemoryModeType.Maximum)
+                        await _vaeEncoder.UnloadAsync();
+
                     var outputResult = result.ToDenseTensor();
                     var scaledSample = outputResult.MultiplyBy(_vaeEncoder.ScaleFactor);
                     return scheduler.AddNoise(scaledSample, scheduler.CreateRandomSample(scaledSample.Dimensions), timesteps);

--- a/OnnxStack.StableDiffusion/Diffusers/StableDiffusionXL/StableDiffusionXLDiffuser.cs
+++ b/OnnxStack.StableDiffusion/Diffusers/StableDiffusionXL/StableDiffusionXLDiffuser.cs
@@ -26,8 +26,8 @@ namespace OnnxStack.StableDiffusion.Diffusers.StableDiffusionXL
         /// <param name="vaeDecoder">The vae decoder.</param>
         /// <param name="vaeEncoder">The vae encoder.</param>
         /// <param name="logger">The logger.</param>
-        public StableDiffusionXLDiffuser(UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, ILogger logger = default)
-            : base(unet, vaeDecoder, vaeEncoder, logger) { }
+        public StableDiffusionXLDiffuser(UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, MemoryModeType memoryMode, ILogger logger = default)
+            : base(unet, vaeDecoder, vaeEncoder, memoryMode, logger) { }
 
 
         /// <summary>
@@ -106,6 +106,10 @@ namespace OnnxStack.StableDiffusion.Diffusers.StableDiffusionXL
                     ReportProgress(progressCallback, step, timesteps.Count, latents);
                     _logger?.LogEnd($"Step {step}/{timesteps.Count}", stepTime);
                 }
+
+                // Unload if required
+                if (_memoryMode != MemoryModeType.Maximum)
+                    await _unet.UnloadAsync();
 
                 // Decode Latents
                 return await DecodeLatentsAsync(promptOptions, schedulerOptions, latents);

--- a/OnnxStack.StableDiffusion/Diffusers/StableDiffusionXL/TextDiffuser.cs
+++ b/OnnxStack.StableDiffusion/Diffusers/StableDiffusionXL/TextDiffuser.cs
@@ -20,8 +20,8 @@ namespace OnnxStack.StableDiffusion.Diffusers.StableDiffusionXL
         /// <param name="vaeDecoder">The vae decoder.</param>
         /// <param name="vaeEncoder">The vae encoder.</param>
         /// <param name="logger">The logger.</param>
-        public TextDiffuser(UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, ILogger logger = default)
-            : base(unet, vaeDecoder, vaeEncoder, logger) { }
+        public TextDiffuser(UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, MemoryModeType memoryMode, ILogger logger = default)
+            : base(unet, vaeDecoder, vaeEncoder, memoryMode, logger) { }
 
 
         /// <summary>

--- a/OnnxStack.StableDiffusion/Enums/MemoryModeType.cs
+++ b/OnnxStack.StableDiffusion/Enums/MemoryModeType.cs
@@ -1,0 +1,10 @@
+﻿namespace OnnxStack.StableDiffusion.Enums
+{
+    public enum MemoryModeType
+    {
+        Maximum = 0,
+        Medium = 1,
+        Minimum = 2
+    }
+
+}

--- a/OnnxStack.StableDiffusion/Helpers/ModelFactory.cs
+++ b/OnnxStack.StableDiffusion/Helpers/ModelFactory.cs
@@ -22,7 +22,7 @@ namespace OnnxStack.StableDiffusion.Helpers
         /// <param name="deviceId">The device identifier.</param>
         /// <param name="executionProvider">The execution provider.</param>
         /// <returns></returns>
-        public static StableDiffusionModelSet CreateModelSet(string modelFolder, DiffuserPipelineType pipeline, ModelType modelType, int deviceId, ExecutionProvider executionProvider)
+        public static StableDiffusionModelSet CreateModelSet(string modelFolder, DiffuserPipelineType pipeline, ModelType modelType, int deviceId, ExecutionProvider executionProvider, MemoryModeType memoryMode)
         {
             var tokenizerPath = Path.Combine(modelFolder, "tokenizer", "model.onnx");
             if (!File.Exists(tokenizerPath))
@@ -117,6 +117,7 @@ namespace OnnxStack.StableDiffusion.Helpers
                 PipelineType = pipeline,
                 Diffusers = diffusers,
                 DeviceId = deviceId,
+                MemoryMode = memoryMode,
                 ExecutionProvider = executionProvider,
                 SchedulerOptions = GetDefaultSchedulerOptions(pipeline, modelType),
                 TokenizerConfig = tokenizerConfig,

--- a/OnnxStack.StableDiffusion/Pipelines/Base/PipelineBase.cs
+++ b/OnnxStack.StableDiffusion/Pipelines/Base/PipelineBase.cs
@@ -18,14 +18,16 @@ namespace OnnxStack.StableDiffusion.Pipelines
     public abstract class PipelineBase : IPipeline
     {
         protected readonly ILogger _logger;
+        protected readonly PipelineOptions _pipelineOptions;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PipelineBase"/> class.
         /// </summary>
         /// <param name="logger">The logger.</param>
-        protected PipelineBase(ILogger logger)
+        protected PipelineBase(PipelineOptions pipelineOptions, ILogger logger)
         {
             _logger = logger;
+            _pipelineOptions = pipelineOptions;
         }
 
 

--- a/OnnxStack.StableDiffusion/Pipelines/LatentConsistencyXLPipeline.cs
+++ b/OnnxStack.StableDiffusion/Pipelines/LatentConsistencyXLPipeline.cs
@@ -23,7 +23,7 @@ namespace OnnxStack.StableDiffusion.Pipelines
         /// <summary>
         /// Initializes a new instance of the <see cref="LatentConsistencyXLPipeline"/> class.
         /// </summary>
-        /// <param name="name">The model name.</param>
+        /// <param name="pipelineOptions">The pipeline options</param>
         /// <param name="tokenizer">The tokenizer.</param>
         /// <param name="tokenizer2">The tokenizer2.</param>
         /// <param name="textEncoder">The text encoder.</param>
@@ -32,8 +32,8 @@ namespace OnnxStack.StableDiffusion.Pipelines
         /// <param name="vaeDecoder">The vae decoder.</param>
         /// <param name="vaeEncoder">The vae encoder.</param>
         /// <param name="logger">The logger.</param>
-        public LatentConsistencyXLPipeline(string name, TokenizerModel tokenizer, TokenizerModel tokenizer2, TextEncoderModel textEncoder, TextEncoderModel textEncoder2, UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, List<DiffuserType> diffusers, SchedulerOptions defaultSchedulerOptions = default, ILogger logger = default)
-            : base(name, tokenizer, tokenizer2, textEncoder, textEncoder2, unet, vaeDecoder, vaeEncoder, diffusers, defaultSchedulerOptions, logger)
+        public LatentConsistencyXLPipeline(PipelineOptions pipelineOptions, TokenizerModel tokenizer, TokenizerModel tokenizer2, TextEncoderModel textEncoder, TextEncoderModel textEncoder2, UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, List<DiffuserType> diffusers, SchedulerOptions defaultSchedulerOptions = default, ILogger logger = default)
+            : base(pipelineOptions, tokenizer, tokenizer2, textEncoder, textEncoder2, unet, vaeDecoder, vaeEncoder, diffusers, defaultSchedulerOptions, logger)
         {
             _supportedSchedulers = new List<SchedulerType>
             {
@@ -100,11 +100,11 @@ namespace OnnxStack.StableDiffusion.Pipelines
         {
             return diffuserType switch
             {
-                DiffuserType.TextToImage => new TextDiffuser(_unet, _vaeDecoder, _vaeEncoder, _logger),
-                DiffuserType.ImageToImage => new ImageDiffuser(_unet, _vaeDecoder, _vaeEncoder, _logger),
-                DiffuserType.ImageInpaintLegacy => new InpaintLegacyDiffuser(_unet, _vaeDecoder, _vaeEncoder, _logger),
-                DiffuserType.ControlNet => new ControlNetDiffuser(controlNetModel, _unet, _vaeDecoder, _vaeEncoder, _logger),
-                DiffuserType.ControlNetImage => new ControlNetImageDiffuser(controlNetModel, _unet, _vaeDecoder, _vaeEncoder, _logger),
+                DiffuserType.TextToImage => new TextDiffuser(_unet, _vaeDecoder, _vaeEncoder, _pipelineOptions.MemoryMode, _logger),
+                DiffuserType.ImageToImage => new ImageDiffuser(_unet, _vaeDecoder, _vaeEncoder, _pipelineOptions.MemoryMode, _logger),
+                DiffuserType.ImageInpaintLegacy => new InpaintLegacyDiffuser(_unet, _vaeDecoder, _vaeEncoder, _pipelineOptions.MemoryMode, _logger),
+                DiffuserType.ControlNet => new ControlNetDiffuser(controlNetModel, _unet, _vaeDecoder, _vaeEncoder, _pipelineOptions.MemoryMode, _logger),
+                DiffuserType.ControlNetImage => new ControlNetImageDiffuser(controlNetModel, _unet, _vaeDecoder, _vaeEncoder, _pipelineOptions.MemoryMode, _logger),
                 _ => throw new NotImplementedException()
             };
         }
@@ -125,7 +125,8 @@ namespace OnnxStack.StableDiffusion.Pipelines
             var textEncoder2 = new TextEncoderModel(modelSet.TextEncoder2Config.ApplyDefaults(modelSet));
             var vaeDecoder = new AutoEncoderModel(modelSet.VaeDecoderConfig.ApplyDefaults(modelSet));
             var vaeEncoder = new AutoEncoderModel(modelSet.VaeEncoderConfig.ApplyDefaults(modelSet));
-            return new LatentConsistencyXLPipeline(modelSet.Name, tokenizer, tokenizer2, textEncoder, textEncoder2, unet, vaeDecoder, vaeEncoder, modelSet.Diffusers, modelSet.SchedulerOptions, logger);
+            var pipelineOptions = new PipelineOptions(modelSet.Name, modelSet.MemoryMode);
+            return new LatentConsistencyXLPipeline(pipelineOptions, tokenizer, tokenizer2, textEncoder, textEncoder2, unet, vaeDecoder, vaeEncoder, modelSet.Diffusers, modelSet.SchedulerOptions, logger);
         }
 
 
@@ -138,9 +139,9 @@ namespace OnnxStack.StableDiffusion.Pipelines
         /// <param name="executionProvider">The execution provider.</param>
         /// <param name="logger">The logger.</param>
         /// <returns></returns>
-        public static new LatentConsistencyXLPipeline CreatePipeline(string modelFolder, ModelType modelType = ModelType.Base, int deviceId = 0, ExecutionProvider executionProvider = ExecutionProvider.DirectML, ILogger logger = default)
+        public static new LatentConsistencyXLPipeline CreatePipeline(string modelFolder, ModelType modelType = ModelType.Base, int deviceId = 0, ExecutionProvider executionProvider = ExecutionProvider.DirectML, MemoryModeType memoryMode = MemoryModeType.Maximum, ILogger logger = default)
         {
-            return CreatePipeline(ModelFactory.CreateModelSet(modelFolder, DiffuserPipelineType.LatentConsistencyXL, modelType, deviceId, executionProvider), logger);
+            return CreatePipeline(ModelFactory.CreateModelSet(modelFolder, DiffuserPipelineType.LatentConsistencyXL, modelType, deviceId, executionProvider, memoryMode), logger);
         }
     }
 }

--- a/OnnxStack.StableDiffusion/Pipelines/StableDiffusionPipeline.cs
+++ b/OnnxStack.StableDiffusion/Pipelines/StableDiffusionPipeline.cs
@@ -21,13 +21,12 @@ namespace OnnxStack.StableDiffusion.Pipelines
 {
     public class StableDiffusionPipeline : PipelineBase
     {
-        protected readonly string _name;
         protected readonly UNetConditionModel _unet;
         protected readonly TokenizerModel _tokenizer;
         protected readonly TextEncoderModel _textEncoder;
-        protected readonly AutoEncoderModel _vaeDecoder;
-        protected readonly AutoEncoderModel _vaeEncoder;
 
+        protected AutoEncoderModel _vaeDecoder;
+        protected AutoEncoderModel _vaeEncoder;
         protected OnnxModelSession _controlNet;
         protected List<DiffuserType> _supportedDiffusers;
         protected IReadOnlyList<SchedulerType> _supportedSchedulers;
@@ -36,16 +35,15 @@ namespace OnnxStack.StableDiffusion.Pipelines
         /// <summary>
         /// Initializes a new instance of the <see cref="StableDiffusionPipeline"/> class.
         /// </summary>
-        /// <param name="name">The model name.</param>
+        /// <param name="pipelineOptions">The pipeline options</param>
         /// <param name="tokenizer">The tokenizer.</param>
         /// <param name="textEncoder">The text encoder.</param>
         /// <param name="unet">The unet.</param>
         /// <param name="vaeDecoder">The vae decoder.</param>
         /// <param name="vaeEncoder">The vae encoder.</param>
         /// <param name="logger">The logger.</param>
-        public StableDiffusionPipeline(string name, TokenizerModel tokenizer, TextEncoderModel textEncoder, UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, List<DiffuserType> diffusers = default, SchedulerOptions defaultSchedulerOptions = default, ILogger logger = default) : base(logger)
+        public StableDiffusionPipeline(PipelineOptions pipelineOptions, TokenizerModel tokenizer, TextEncoderModel textEncoder, UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, List<DiffuserType> diffusers = default, SchedulerOptions defaultSchedulerOptions = default, ILogger logger = default) : base(pipelineOptions, logger)
         {
-            _name = name;
             _unet = unet;
             _tokenizer = tokenizer;
             _textEncoder = textEncoder;
@@ -78,7 +76,7 @@ namespace OnnxStack.StableDiffusion.Pipelines
         /// <summary>
         /// Gets the name.
         /// </summary>
-        public override string Name => _name;
+        public override string Name => _pipelineOptions.Name;
 
 
         /// <summary>
@@ -110,12 +108,24 @@ namespace OnnxStack.StableDiffusion.Pipelines
         /// </summary>
         public override Task LoadAsync()
         {
-            return Task.WhenAll(
-                _unet.LoadAsync(),
-                _tokenizer.LoadAsync(),
-                _textEncoder.LoadAsync(),
-                _vaeDecoder.LoadAsync(),
-                _vaeEncoder.LoadAsync());
+            if (_pipelineOptions.MemoryMode == MemoryModeType.Maximum)
+            {
+                return Task.WhenAll(
+                    _unet.LoadAsync(),
+                    _tokenizer.LoadAsync(), 
+                    _textEncoder.LoadAsync(),
+                    _vaeDecoder.LoadAsync(), 
+                    _vaeEncoder.LoadAsync());
+            }
+
+            if (_pipelineOptions.MemoryMode == MemoryModeType.Medium)
+            {
+                return Task.WhenAll(
+                    _unet.LoadAsync(), 
+                    _tokenizer.LoadAsync(),
+                    _textEncoder.LoadAsync());
+            }
+            return Task.CompletedTask;
         }
 
 
@@ -232,6 +242,32 @@ namespace OnnxStack.StableDiffusion.Pipelines
 
 
         /// <summary>
+        /// Overrides the vae encoder with a custom implementation, Caller is responsible for model lifetime
+        /// </summary>
+        /// <param name="vaeEncoder">The vae encoder.</param>
+        public void OverrideVaeEncoder(AutoEncoderModel vaeEncoder)
+        {
+            if (_vaeEncoder != null)
+                _vaeEncoder.Dispose();
+
+            _vaeEncoder = vaeEncoder;
+        }
+
+
+        /// <summary>
+        /// Overrides the vae decoder with a custom implementation, Caller is responsible for model lifetime
+        /// </summary>
+        /// <param name="vaeDecoder">The vae decoder.</param>
+        public void OverrideVaeDecoder(AutoEncoderModel vaeDecoder)
+        {
+            if (_vaeDecoder != null)
+                _vaeDecoder.Dispose();
+
+            _vaeDecoder = vaeDecoder;
+        }
+
+
+        /// <summary>
         /// Creates the diffuser.
         /// </summary>
         /// <param name="diffuserType">Type of the diffuser.</param>
@@ -241,12 +277,12 @@ namespace OnnxStack.StableDiffusion.Pipelines
         {
             return diffuserType switch
             {
-                DiffuserType.TextToImage => new TextDiffuser(_unet, _vaeDecoder, _vaeEncoder, _logger),
-                DiffuserType.ImageToImage => new ImageDiffuser(_unet, _vaeDecoder, _vaeEncoder, _logger),
-                DiffuserType.ImageInpaint => new InpaintDiffuser(_unet, _vaeDecoder, _vaeEncoder, _logger),
-                DiffuserType.ImageInpaintLegacy => new InpaintLegacyDiffuser(_unet, _vaeDecoder, _vaeEncoder, _logger),
-                DiffuserType.ControlNet => new ControlNetDiffuser(controlNetModel, _unet, _vaeDecoder, _vaeEncoder, _logger),
-                DiffuserType.ControlNetImage => new ControlNetImageDiffuser(controlNetModel, _unet, _vaeDecoder, _vaeEncoder, _logger),
+                DiffuserType.TextToImage => new TextDiffuser(_unet, _vaeDecoder, _vaeEncoder, _pipelineOptions.MemoryMode, _logger),
+                DiffuserType.ImageToImage => new ImageDiffuser(_unet, _vaeDecoder, _vaeEncoder, _pipelineOptions.MemoryMode, _logger),
+                DiffuserType.ImageInpaint => new InpaintDiffuser(_unet, _vaeDecoder, _vaeEncoder, _pipelineOptions.MemoryMode, _logger),
+                DiffuserType.ImageInpaintLegacy => new InpaintLegacyDiffuser(_unet, _vaeDecoder, _vaeEncoder, _pipelineOptions.MemoryMode, _logger),
+                DiffuserType.ControlNet => new ControlNetDiffuser(controlNetModel, _unet, _vaeDecoder, _vaeEncoder, _pipelineOptions.MemoryMode, _logger),
+                DiffuserType.ControlNetImage => new ControlNetImageDiffuser(controlNetModel, _unet, _vaeDecoder, _vaeEncoder, _pipelineOptions.MemoryMode, _logger),
                 _ => throw new NotImplementedException()
             };
         }
@@ -268,6 +304,13 @@ namespace OnnxStack.StableDiffusion.Pipelines
             // Generate embeds for tokens
             var promptEmbeddings = await GeneratePromptEmbedsAsync(promptTokens, maxPromptTokenCount);
             var negativePromptEmbeddings = await GeneratePromptEmbedsAsync(negativePromptTokens, maxPromptTokenCount);
+
+
+            if (_pipelineOptions.MemoryMode == MemoryModeType.Minimum)
+            {
+                await _tokenizer.UnloadAsync();
+                await _textEncoder.UnloadAsync();
+            }
 
             if (isGuidanceEnabled)
                 return new PromptEmbeddingsResult(negativePromptEmbeddings.Concatenate(promptEmbeddings));
@@ -380,7 +423,8 @@ namespace OnnxStack.StableDiffusion.Pipelines
             var textEncoder = new TextEncoderModel(modelSet.TextEncoderConfig.ApplyDefaults(modelSet));
             var vaeDecoder = new AutoEncoderModel(modelSet.VaeDecoderConfig.ApplyDefaults(modelSet));
             var vaeEncoder = new AutoEncoderModel(modelSet.VaeEncoderConfig.ApplyDefaults(modelSet));
-            return new StableDiffusionPipeline(modelSet.Name, tokenizer, textEncoder, unet, vaeDecoder, vaeEncoder, modelSet.Diffusers, modelSet.SchedulerOptions, logger);
+            var pipelineOptions = new PipelineOptions(modelSet.Name, modelSet.MemoryMode);
+            return new StableDiffusionPipeline(pipelineOptions, tokenizer, textEncoder, unet, vaeDecoder, vaeEncoder, modelSet.Diffusers, modelSet.SchedulerOptions, logger);
         }
 
 
@@ -393,9 +437,10 @@ namespace OnnxStack.StableDiffusion.Pipelines
         /// <param name="executionProvider">The execution provider.</param>
         /// <param name="logger">The logger.</param>
         /// <returns></returns>
-        public static StableDiffusionPipeline CreatePipeline(string modelFolder, ModelType modelType = ModelType.Base, int deviceId = 0, ExecutionProvider executionProvider = ExecutionProvider.DirectML, ILogger logger = default)
+        public static StableDiffusionPipeline CreatePipeline(string modelFolder, ModelType modelType = ModelType.Base, int deviceId = 0, ExecutionProvider executionProvider = ExecutionProvider.DirectML, MemoryModeType memoryMode = MemoryModeType.Maximum, ILogger logger = default)
         {
-            return CreatePipeline(ModelFactory.CreateModelSet(modelFolder, DiffuserPipelineType.StableDiffusion, modelType, deviceId, executionProvider), logger);
+            return CreatePipeline(ModelFactory.CreateModelSet(modelFolder, DiffuserPipelineType.StableDiffusion, modelType, deviceId, executionProvider, memoryMode), logger);
         }
     }
+
 }

--- a/OnnxStack.StableDiffusion/Pipelines/StableDiffusionXLPipeline.cs
+++ b/OnnxStack.StableDiffusion/Pipelines/StableDiffusionXLPipeline.cs
@@ -25,7 +25,7 @@ namespace OnnxStack.StableDiffusion.Pipelines
         /// <summary>
         /// Initializes a new instance of the <see cref="StableDiffusionXLPipeline"/> class.
         /// </summary>
-        /// <param name="name">The model name.</param>
+        /// <param name="pipelineOptions">The pipeline options</param>
         /// <param name="tokenizer">The tokenizer.</param>
         /// <param name="tokenizer2">The tokenizer2.</param>
         /// <param name="textEncoder">The text encoder.</param>
@@ -34,8 +34,8 @@ namespace OnnxStack.StableDiffusion.Pipelines
         /// <param name="vaeDecoder">The vae decoder.</param>
         /// <param name="vaeEncoder">The vae encoder.</param>
         /// <param name="logger">The logger.</param>
-        public StableDiffusionXLPipeline(string name, TokenizerModel tokenizer, TokenizerModel tokenizer2, TextEncoderModel textEncoder, TextEncoderModel textEncoder2, UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, List<DiffuserType> diffusers, SchedulerOptions defaultSchedulerOptions = default, ILogger logger = default)
-            : base(name, tokenizer, textEncoder, unet, vaeDecoder, vaeEncoder, diffusers, defaultSchedulerOptions, logger)
+        public StableDiffusionXLPipeline(PipelineOptions pipelineOptions, TokenizerModel tokenizer, TokenizerModel tokenizer2, TextEncoderModel textEncoder, TextEncoderModel textEncoder2, UNetConditionModel unet, AutoEncoderModel vaeDecoder, AutoEncoderModel vaeEncoder, List<DiffuserType> diffusers, SchedulerOptions defaultSchedulerOptions = default, ILogger logger = default)
+            : base(pipelineOptions, tokenizer, textEncoder, unet, vaeDecoder, vaeEncoder, diffusers, defaultSchedulerOptions, logger)
         {
             _tokenizer2 = tokenizer2;
             _textEncoder2 = textEncoder2;
@@ -66,12 +66,16 @@ namespace OnnxStack.StableDiffusion.Pipelines
         /// <summary>
         /// Loads the pipeline
         /// </summary>
-        public override async Task LoadAsync()
+        public override Task LoadAsync()
         {
-            await Task.WhenAll(
-                _tokenizer2.LoadAsync(),
-                _textEncoder2.LoadAsync(),
-                 base.LoadAsync());
+            if (_pipelineOptions.MemoryMode != MemoryModeType.Minimum)
+            {
+                return Task.WhenAll(
+                    _tokenizer2.LoadAsync(),
+                    _textEncoder2.LoadAsync(), 
+                    base.LoadAsync());
+            }
+            return base.LoadAsync();
         }
 
 
@@ -97,11 +101,11 @@ namespace OnnxStack.StableDiffusion.Pipelines
         {
             return diffuserType switch
             {
-                DiffuserType.TextToImage => new TextDiffuser(_unet, _vaeDecoder, _vaeEncoder, _logger),
-                DiffuserType.ImageToImage => new ImageDiffuser(_unet, _vaeDecoder, _vaeEncoder, _logger),
-                DiffuserType.ImageInpaintLegacy => new InpaintLegacyDiffuser(_unet, _vaeDecoder, _vaeEncoder, _logger),
-                DiffuserType.ControlNet => new ControlNetDiffuser(controlNetModel, _unet, _vaeDecoder, _vaeEncoder, _logger),
-                DiffuserType.ControlNetImage => new ControlNetImageDiffuser(controlNetModel, _unet, _vaeDecoder, _vaeEncoder, _logger),
+                DiffuserType.TextToImage => new TextDiffuser(_unet, _vaeDecoder, _vaeEncoder, _pipelineOptions.MemoryMode, _logger),
+                DiffuserType.ImageToImage => new ImageDiffuser(_unet, _vaeDecoder, _vaeEncoder, _pipelineOptions.MemoryMode, _logger),
+                DiffuserType.ImageInpaintLegacy => new InpaintLegacyDiffuser(_unet, _vaeDecoder, _vaeEncoder, _pipelineOptions.MemoryMode, _logger),
+                DiffuserType.ControlNet => new ControlNetDiffuser(controlNetModel, _unet, _vaeDecoder, _vaeEncoder, _pipelineOptions.MemoryMode, _logger),
+                DiffuserType.ControlNetImage => new ControlNetImageDiffuser(controlNetModel, _unet, _vaeDecoder, _vaeEncoder, _pipelineOptions.MemoryMode, _logger),
                 _ => throw new NotImplementedException()
             };
         }
@@ -139,6 +143,13 @@ namespace OnnxStack.StableDiffusion.Pipelines
             // Generate embeds for tokens
             var promptEmbeddings = await GenerateEmbedsAsync(promptTokens, maxPromptTokenCount);
             var negativePromptEmbeddings = await GenerateEmbedsAsync(negativePromptTokens, maxPromptTokenCount);
+
+            // Unload if required
+            if (_pipelineOptions.MemoryMode == MemoryModeType.Minimum)
+            {
+                await _tokenizer2.UnloadAsync();
+                await _textEncoder2.UnloadAsync();
+            }
 
             if (isGuidanceEnabled)
                 return new PromptEmbeddingsResult(
@@ -179,6 +190,13 @@ namespace OnnxStack.StableDiffusion.Pipelines
             var dualNegativePrompt = negativePromptEmbeddings.Concatenate(dualNegativePromptEmbeddings.PromptEmbeds, 2);
             var pooledPromptEmbeds = dualPromptEmbeddings.PooledPromptEmbeds;
             var pooledNegativePromptEmbeds = dualNegativePromptEmbeddings.PooledPromptEmbeds;
+
+            // Unload if required
+            if (_pipelineOptions.MemoryMode == MemoryModeType.Minimum)
+            {
+                await _tokenizer2.UnloadAsync();
+                await _textEncoder2.UnloadAsync();
+            }
 
             if (isGuidanceEnabled)
                 return new PromptEmbeddingsResult(dualNegativePrompt.Concatenate(dualPrompt), pooledNegativePromptEmbeds.Concatenate(pooledPromptEmbeds));
@@ -302,7 +320,8 @@ namespace OnnxStack.StableDiffusion.Pipelines
             var textEncoder2 = new TextEncoderModel(modelSet.TextEncoder2Config.ApplyDefaults(modelSet));
             var vaeDecoder = new AutoEncoderModel(modelSet.VaeDecoderConfig.ApplyDefaults(modelSet));
             var vaeEncoder = new AutoEncoderModel(modelSet.VaeEncoderConfig.ApplyDefaults(modelSet));
-            return new StableDiffusionXLPipeline(modelSet.Name, tokenizer, tokenizer2, textEncoder, textEncoder2, unet, vaeDecoder, vaeEncoder, modelSet.Diffusers, modelSet.SchedulerOptions, logger);
+            var pipelineOptions = new PipelineOptions(modelSet.Name, modelSet.MemoryMode);
+            return new StableDiffusionXLPipeline(pipelineOptions, tokenizer, tokenizer2, textEncoder, textEncoder2, unet, vaeDecoder, vaeEncoder, modelSet.Diffusers, modelSet.SchedulerOptions, logger);
         }
 
 
@@ -315,9 +334,9 @@ namespace OnnxStack.StableDiffusion.Pipelines
         /// <param name="executionProvider">The execution provider.</param>
         /// <param name="logger">The logger.</param>
         /// <returns></returns>
-        public static new StableDiffusionXLPipeline CreatePipeline(string modelFolder, ModelType modelType = ModelType.Base, int deviceId = 0, ExecutionProvider executionProvider = ExecutionProvider.DirectML, ILogger logger = default)
+        public static new StableDiffusionXLPipeline CreatePipeline(string modelFolder, ModelType modelType = ModelType.Base, int deviceId = 0, ExecutionProvider executionProvider = ExecutionProvider.DirectML, MemoryModeType memoryMode = MemoryModeType.Maximum, ILogger logger = default)
         {
-            return CreatePipeline(ModelFactory.CreateModelSet(modelFolder, DiffuserPipelineType.StableDiffusionXL, modelType, deviceId, executionProvider), logger);
+            return CreatePipeline(ModelFactory.CreateModelSet(modelFolder, DiffuserPipelineType.StableDiffusionXL, modelType, deviceId, executionProvider, memoryMode), logger);
         }
     }
 }


### PR DESCRIPTION
Add some memory profiles to give users with low end cards to use stable diffusion

**3 Modes**
`Maximum` = Keep all models cached in memory
`Medium` = Keep text models cached, Unload each model after inference
`Minimum` = Unload each model after inference

**Memory Benchmarks:**

| Model| Maximum | Medium | Minimum |
| :--- | :--- | :--- | :--- |
StableDiffusion | 7.2GB | 5.8GB | 5.4GB
StableDiffusion Olive | 4GB | 2.4GB | 2.1GB
SDXL | 27GB | 20GB | 18GB
SDXL Olive | 14.2GB | 8.5GB | 7.2GB
