### PR TITLE
Video Stream Support

### DIFF
--- a/OnnxStack.Console/Examples/FeatureExtractorVideoExample.cs
+++ b/OnnxStack.Console/Examples/FeatureExtractorVideoExample.cs
@@ -1,0 +1,50 @@
+﻿using OnnxStack.Core.Video;
+using OnnxStack.FeatureExtractor.Pipelines;
+using OnnxStack.StableDiffusion.Config;
+
+namespace OnnxStack.Console.Runner
+{
+    public sealed class FeatureExtractorVideoExample : IExampleRunner
+    {
+        private readonly string _outputDirectory;
+        private readonly StableDiffusionConfig _configuration;
+
+        public FeatureExtractorVideoExample(StableDiffusionConfig configuration)
+        {
+            _configuration = configuration;
+            _outputDirectory = Path.Combine(Directory.GetCurrentDirectory(), "Examples", nameof(FeatureExtractorVideoExample));
+            Directory.CreateDirectory(_outputDirectory);
+        }
+
+        public int Index => 13;
+
+        public string Name => "Feature Extractor Video Example";
+
+        public string Description => "Video exmaple using basic feature extractor";
+
+        /// <summary>
+        /// ControlNet Example
+        /// </summary>
+        public async Task RunAsync()
+        {
+            // Read Video
+            var videoFile = "C:\\Users\\Deven\\Pictures\\parrot.mp4";
+            var videoInfo = await VideoHelper.ReadVideoInfoAsync(videoFile);
+
+            // Create pipeline
+            var pipeline = FeatureExtractorPipeline.CreatePipeline("D:\\Repositories\\controlnet_onnx\\annotators\\canny.onnx");
+
+            // Create Video Stream
+            var videoStream = VideoHelper.ReadVideoStreamAsync(videoFile, videoInfo.FrameRate);
+
+            // Create Pipeline Stream
+            var pipelineStream = pipeline.RunAsync(videoStream);
+
+            // Write Video Stream
+            await VideoHelper.WriteVideoStreamAsync(videoInfo, pipelineStream, Path.Combine(_outputDirectory, $"Result.mp4"));
+
+            //Unload
+            await pipeline.UnloadAsync();
+        }
+    }
+}

--- a/OnnxStack.Console/Examples/UpscaleExample.cs
+++ b/OnnxStack.Console/Examples/UpscaleExample.cs
@@ -29,13 +29,10 @@ namespace OnnxStack.Console.Runner
 
             // Run pipeline
             var result = await pipeline.RunAsync(inputImage);
-
-            // Create Image from Tensor result
-            var image = new OnnxImage(result, ImageNormalizeType.ZeroToOne);
-
+         
             // Save Image File
             var outputFilename = Path.Combine(_outputDirectory, $"Upscaled.png");
-            await image.SaveAsync(outputFilename);
+            await result.SaveAsync(outputFilename);
 
             // Unload
             await pipeline.UnloadAsync();

--- a/OnnxStack.Console/Examples/UpscaleStreamExample.cs
+++ b/OnnxStack.Console/Examples/UpscaleStreamExample.cs
@@ -1,0 +1,48 @@
+﻿using OnnxStack.Core.Video;
+using OnnxStack.FeatureExtractor.Pipelines;
+
+namespace OnnxStack.Console.Runner
+{
+    public sealed class UpscaleStreamExample : IExampleRunner
+    {
+        private readonly string _outputDirectory;
+
+        public UpscaleStreamExample()
+        {
+            _outputDirectory = Path.Combine(Directory.GetCurrentDirectory(), "Examples", nameof(UpscaleStreamExample));
+            Directory.CreateDirectory(_outputDirectory);
+        }
+
+        public int Index => 10;
+
+        public string Name => "Streaming Video Upscale Demo";
+
+        public string Description => "Upscales a video stream";
+
+        public async Task RunAsync()
+        {
+            // Read Video
+            var videoFile = "C:\\Users\\Deven\\Pictures\\parrot.mp4";
+            var videoInfo = await VideoHelper.ReadVideoInfoAsync(videoFile);
+
+            // Create pipeline
+            var pipeline = ImageUpscalePipeline.CreatePipeline("D:\\Repositories\\upscaler\\SwinIR\\003_realSR_BSRGAN_DFO_s64w8_SwinIR-M_x4_GAN.onnx", 4);
+
+            // Load pipeline
+            await pipeline.LoadAsync();
+
+            // Create Video Stream
+            var videoStream = VideoHelper.ReadVideoStreamAsync(videoFile, videoInfo.FrameRate);
+
+            // Create Pipeline Stream
+            var pipelineStream = pipeline.RunAsync(videoStream);
+
+            // Write Video Stream
+            await VideoHelper.WriteVideoStreamAsync(videoInfo, pipelineStream, Path.Combine(_outputDirectory, $"Result.mp4"));
+
+            //Unload
+            await pipeline.UnloadAsync();
+        }
+
+    }
+}

--- a/OnnxStack.Console/Examples/VideoToVideoStreamExample.cs
+++ b/OnnxStack.Console/Examples/VideoToVideoStreamExample.cs
@@ -1,0 +1,67 @@
+﻿using OnnxStack.Core.Video;
+using OnnxStack.FeatureExtractor.Pipelines;
+using OnnxStack.StableDiffusion.Config;
+using OnnxStack.StableDiffusion.Enums;
+using OnnxStack.StableDiffusion.Pipelines;
+
+namespace OnnxStack.Console.Runner
+{
+    public sealed class VideoToVideoStreamExample : IExampleRunner
+    {
+        private readonly string _outputDirectory;
+        private readonly StableDiffusionConfig _configuration;
+
+        public VideoToVideoStreamExample(StableDiffusionConfig configuration)
+        {
+            _configuration = configuration;
+            _outputDirectory = Path.Combine(Directory.GetCurrentDirectory(), "Examples", nameof(VideoToVideoStreamExample));
+            Directory.CreateDirectory(_outputDirectory);
+        }
+
+        public int Index => 4;
+
+        public string Name => "Video To Video Stream Demo";
+
+        public string Description => "Video Stream Stable Diffusion Inference";
+
+        public async Task RunAsync()
+        {
+
+            // Read Video
+            var videoFile = "C:\\Users\\Deven\\Pictures\\gidsgphy.gif";
+            var videoInfo = await VideoHelper.ReadVideoInfoAsync(videoFile);
+
+            // Loop though the appsettings.json model sets
+            foreach (var modelSet in _configuration.ModelSets)
+            {
+                OutputHelpers.WriteConsole($"Loading Model `{modelSet.Name}`...", ConsoleColor.Cyan);
+
+                // Create Pipeline
+                var pipeline = PipelineBase.CreatePipeline(modelSet);
+
+                // Preload Models (optional)
+                await pipeline.LoadAsync();
+
+                // Add text and video to prompt
+                var promptOptions = new PromptOptions
+                {
+                    Prompt = "Iron Man",
+                    DiffuserType = DiffuserType.ImageToImage
+                };
+
+
+                // Create Video Stream
+                var videoStream = VideoHelper.ReadVideoStreamAsync(videoFile, videoInfo.FrameRate);
+
+                // Create Pipeline Stream
+                var pipelineStream = pipeline.GenerateVideoStreamAsync(videoStream, promptOptions, progressCallback:OutputHelpers.ProgressCallback);
+
+                // Write Video Stream
+                await VideoHelper.WriteVideoStreamAsync(videoInfo, pipelineStream, Path.Combine(_outputDirectory, $"{modelSet.PipelineType}.mp4"));
+
+                //Unload
+                await pipeline.UnloadAsync();
+            }
+        }
+    }
+}

--- a/OnnxStack.Core/Extensions/TensorExtension.cs
+++ b/OnnxStack.Core/Extensions/TensorExtension.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.ML.OnnxRuntime.Tensors;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace OnnxStack.Core
 {
@@ -72,6 +73,33 @@ namespace OnnxStack.Core
                 var start = i * newLength;
                 yield return new DenseTensor<float>(tensor.Buffer.Slice(start, newLength), dimensions);
             }
+        }
+
+
+        /// <summary>
+        /// Joins the tensors across the 0 axis.
+        /// </summary>
+        /// <param name="tensors">The tensors.</param>
+        /// <param name="axis">The axis.</param>
+        /// <returns></returns>
+        /// <exception cref="System.NotImplementedException">Only axis 0 is supported</exception>
+        public static DenseTensor<float> Join(this IList<DenseTensor<float>> tensors, int axis = 0)
+        {
+            if (axis != 0)
+                throw new NotImplementedException("Only axis 0 is supported");
+
+            var tensor = tensors.First();
+            var dimensions = tensor.Dimensions.ToArray();
+            dimensions[0] *= tensors.Count;
+
+            var newLength = (int)tensor.Length;
+            var buffer = new float[newLength * tensors.Count].AsMemory();
+            for (int i = 0; i < tensors.Count(); i++)
+            {
+                var start = i * newLength;
+                tensors[i].Buffer.CopyTo(buffer[start..]);
+            }
+            return new DenseTensor<float>(buffer, dimensions);
         }
 
 

--- a/OnnxStack.Core/Image/OnnxImage.cs
+++ b/OnnxStack.Core/Image/OnnxImage.cs
@@ -145,6 +145,20 @@ namespace OnnxStack.Core.Image
 
 
         /// <summary>
+        /// Gets the image as bytes.
+        /// </summary>
+        /// <returns></returns>
+        public async Task<byte[]> GetImageBytesAsync()
+        {
+            using (var memoryStream = new MemoryStream())
+            {
+                await _imageData.SaveAsPngAsync(memoryStream);
+                return memoryStream.ToArray();
+            }
+        }
+
+
+        /// <summary>
         /// Gets the image as stream.
         /// </summary>
         /// <returns></returns>
@@ -152,6 +166,18 @@ namespace OnnxStack.Core.Image
         {
             var memoryStream = new MemoryStream();
             _imageData.SaveAsPng(memoryStream);
+            return memoryStream;
+        }
+
+
+        /// <summary>
+        /// Gets the image as stream.
+        /// </summary>
+        /// <returns></returns>
+        public async Task<Stream> GetImageStreamAsync()
+        {
+            var memoryStream = new MemoryStream();
+            await _imageData.SaveAsPngAsync(memoryStream);
             return memoryStream;
         }
 

--- a/OnnxStack.Core/Image/OnnxImage.cs
+++ b/OnnxStack.Core/Image/OnnxImage.cs
@@ -183,6 +183,28 @@ namespace OnnxStack.Core.Image
 
 
         /// <summary>
+        /// Copies the image to stream.
+        /// </summary>
+        /// <param name="destination">The destination.</param>
+        /// <returns></returns>
+        public void CopyToStream(Stream destination)
+        {
+            _imageData.SaveAsPng(destination);
+        }
+
+
+        /// <summary>
+        /// Copies the image to stream.
+        /// </summary>
+        /// <param name="destination">The destination.</param>
+        /// <returns></returns>
+        public Task CopyToStreamAsync(Stream destination)
+        {
+            return _imageData.SaveAsPngAsync(destination);
+        }
+
+
+        /// <summary>
         /// Gets the image as tensor.
         /// </summary>
         /// <param name="normalizeType">Type of the normalize.</param>

--- a/OnnxStack.Core/Video/OnnxVideo.cs
+++ b/OnnxStack.Core/Video/OnnxVideo.cs
@@ -88,7 +88,7 @@ namespace OnnxStack.Core.Video
         /// <summary>
         /// Gets the aspect ratio.
         /// </summary>
-        public double AspectRatio => (double)_info.Width / _info.Height;
+        public double AspectRatio => _info.AspectRatio;
 
         /// <summary>
         /// Gets a value indicating whether this instance has video.

--- a/OnnxStack.Core/Video/VideoHelper.cs
+++ b/OnnxStack.Core/Video/VideoHelper.cs
@@ -103,7 +103,7 @@ namespace OnnxStack.Core.Video
                 await foreach (var frame in videoStream)
                 {
                     // Write each frame to the input stream of FFMPEG
-                    await videoWriter.StandardInput.BaseStream.WriteAsync(frame.GetImageBytes(), cancellationToken);
+                    await frame.CopyToStreamAsync(videoWriter.StandardInput.BaseStream);
                 }
 
                 // Done close stream and wait for app to process

--- a/OnnxStack.Core/Video/VideoHelper.cs
+++ b/OnnxStack.Core/Video/VideoHelper.cs
@@ -84,6 +84,36 @@ namespace OnnxStack.Core.Video
 
 
         /// <summary>
+        /// Writes the video stream to file.
+        /// </summary>
+        /// <param name="onnxImages">The onnx image stream.</param>
+        /// <param name="filename">The filename.</param>
+        /// <param name="frameRate">The frame rate.</param>
+        /// <param name="aspectRatio">The aspect ratio.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        public static async Task WriteVideoStreamAsync(VideoInfo videoInfo, IAsyncEnumerable<OnnxImage> videoStream, string filename, CancellationToken cancellationToken = default)
+        {
+            if (File.Exists(filename))
+                File.Delete(filename);
+
+            using (var videoWriter = CreateWriter(filename, videoInfo.FrameRate, videoInfo.AspectRatio))
+            {
+                // Start FFMPEG
+                videoWriter.Start();
+                await foreach (var frame in videoStream)
+                {
+                    // Write each frame to the input stream of FFMPEG
+                    await videoWriter.StandardInput.BaseStream.WriteAsync(frame.GetImageBytes(), cancellationToken);
+                }
+
+                // Done close stream and wait for app to process
+                videoWriter.StandardInput.BaseStream.Close();
+                await videoWriter.WaitForExitAsync(cancellationToken);
+            }
+        }
+
+
+        /// <summary>
         /// Reads the video information.
         /// </summary>
         /// <param name="videoBytes">The video bytes.</param>
@@ -119,9 +149,16 @@ namespace OnnxStack.Core.Video
         /// <returns></returns>
         public static async Task<List<OnnxImage>> ReadVideoFramesAsync(byte[] videoBytes, float frameRate = 15, CancellationToken cancellationToken = default)
         {
-            return await CreateFramesInternalAsync(videoBytes, frameRate, cancellationToken)
-                .Select(x => new OnnxImage(x))
-                .ToListAsync(cancellationToken);
+            string tempVideoPath = GetTempFilename();
+            try
+            {
+                await File.WriteAllBytesAsync(tempVideoPath, videoBytes, cancellationToken);
+                return await ReadVideoStreamAsync(tempVideoPath, frameRate, cancellationToken).ToListAsync(cancellationToken);
+            }
+            finally
+            {
+                DeleteTempFile(tempVideoPath);
+            }
         }
 
 
@@ -134,10 +171,23 @@ namespace OnnxStack.Core.Video
         /// <returns></returns>
         public static async Task<List<OnnxImage>> ReadVideoFramesAsync(string filename, float frameRate = 15, CancellationToken cancellationToken = default)
         {
-            var videoBytes = await File.ReadAllBytesAsync(filename, cancellationToken);
-            return await CreateFramesInternalAsync(videoBytes, frameRate, cancellationToken)
-                .Select(x => new OnnxImage(x))
-                .ToListAsync(cancellationToken);
+            return await ReadVideoStreamAsync(filename, frameRate, cancellationToken).ToListAsync(cancellationToken);
+        }
+
+
+        /// <summary>
+        /// Reads the video frames as a stream.
+        /// </summary>
+        /// <param name="filename">The filename.</param>
+        /// <param name="frameRate">The frame rate.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns></returns>
+        public static async IAsyncEnumerable<OnnxImage> ReadVideoStreamAsync(string filename, float frameRate = 15, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await foreach (var frameBytes in CreateFramesInternalAsync(filename, frameRate, cancellationToken))
+            {
+                yield return new OnnxImage(frameBytes);
+            }
         }
 
 
@@ -152,76 +202,67 @@ namespace OnnxStack.Core.Video
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns></returns>
         /// <exception cref="Exception">Invalid PNG header</exception>
-        private static async IAsyncEnumerable<byte[]> CreateFramesInternalAsync(byte[] videoData, float fps = 15, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        private static async IAsyncEnumerable<byte[]> CreateFramesInternalAsync(string fileName, float fps = 15, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
-            string tempVideoPath = GetTempFilename();
-            try
+            using (var ffmpegProcess = CreateReader(fileName, fps))
             {
-                await File.WriteAllBytesAsync(tempVideoPath, videoData, cancellationToken);
-                using (var ffmpegProcess = CreateReader(tempVideoPath, fps))
+                // Start FFMPEG
+                ffmpegProcess.Start();
+
+                // FFMPEG output stream
+                var processOutputStream = ffmpegProcess.StandardOutput.BaseStream;
+
+                // Buffer to hold the current image
+                var buffer = new byte[20480000];
+
+                var currentIndex = 0;
+                while (!cancellationToken.IsCancellationRequested)
                 {
-                    // Start FFMPEG
-                    ffmpegProcess.Start();
+                    // Reset the index new PNG
+                    currentIndex = 0;
 
-                    // FFMPEG output stream
-                    var processOutputStream = ffmpegProcess.StandardOutput.BaseStream;
+                    // Read the PNG Header
+                    if (await processOutputStream.ReadAsync(buffer.AsMemory(currentIndex, 8), cancellationToken) <= 0)
+                        break;
 
-                    // Buffer to hold the current image
-                    var buffer = new byte[20480000];
+                    currentIndex += 8;// header length
 
-                    var currentIndex = 0;
-                    while (!cancellationToken.IsCancellationRequested)
+                    if (!IsImageHeader(buffer))
+                        throw new Exception("Invalid PNG header");
+
+                    // loop through each chunk
+                    while (true)
                     {
-                        // Reset the index new PNG
-                        currentIndex = 0;
+                        // Read the chunk header
+                        await processOutputStream.ReadAsync(buffer.AsMemory(currentIndex, 12), cancellationToken);
 
-                        // Read the PNG Header
-                        if (await processOutputStream.ReadAsync(buffer.AsMemory(currentIndex, 8), cancellationToken) <= 0)
-                            break;
+                        var chunkIndex = currentIndex;
+                        currentIndex += 12; // Chunk header length
 
-                        currentIndex += 8;// header length
-
-                        if (!IsImageHeader(buffer))
-                            throw new Exception("Invalid PNG header");
-
-                        // loop through each chunk
-                        while (true)
+                        // Get the chunk's content size in bytes from the header we just read
+                        var totalSize = buffer[chunkIndex] << 24 | buffer[chunkIndex + 1] << 16 | buffer[chunkIndex + 2] << 8 | buffer[chunkIndex + 3];
+                        if (totalSize > 0)
                         {
-                            // Read the chunk header
-                            await processOutputStream.ReadAsync(buffer.AsMemory(currentIndex, 12), cancellationToken);
-
-                            var chunkIndex = currentIndex;
-                            currentIndex += 12; // Chunk header length
-
-                            // Get the chunk's content size in bytes from the header we just read
-                            var totalSize = buffer[chunkIndex] << 24 | buffer[chunkIndex + 1] << 16 | buffer[chunkIndex + 2] << 8 | buffer[chunkIndex + 3];
-                            if (totalSize > 0)
+                            var totalRead = 0;
+                            while (totalRead < totalSize)
                             {
-                                var totalRead = 0;
-                                while (totalRead < totalSize)
-                                {
-                                    int read = await processOutputStream.ReadAsync(buffer.AsMemory(currentIndex, totalSize - totalRead), cancellationToken);
-                                    currentIndex += read;
-                                    totalRead += read;
-                                }
-                                continue;
+                                int read = await processOutputStream.ReadAsync(buffer.AsMemory(currentIndex, totalSize - totalRead), cancellationToken);
+                                currentIndex += read;
+                                totalRead += read;
                             }
-
-                            // If the size is 0 and is the end of the image
-                            if (totalSize == 0 && IsImageEnd(buffer, chunkIndex))
-                                break;
+                            continue;
                         }
 
-                        yield return buffer[..currentIndex];
+                        // If the size is 0 and is the end of the image
+                        if (totalSize == 0 && IsImageEnd(buffer, chunkIndex))
+                            break;
                     }
 
-                    if (cancellationToken.IsCancellationRequested)
-                        ffmpegProcess.Kill();
+                    yield return buffer[..currentIndex];
                 }
-            }
-            finally
-            {
-                DeleteTempFile(tempVideoPath);
+
+                if (cancellationToken.IsCancellationRequested)
+                    ffmpegProcess.Kill();
             }
         }
 

--- a/OnnxStack.Core/Video/VideoInfo.cs
+++ b/OnnxStack.Core/Video/VideoInfo.cs
@@ -11,5 +11,7 @@ namespace OnnxStack.Core.Video
         }
         public int Height { get; set; }
         public int Width { get; set; }
+
+        public double AspectRatio => (double)Height / Width;
     }
 }

--- a/OnnxStack.StableDiffusion/Config/PromptOptions.cs
+++ b/OnnxStack.StableDiffusion/Config/PromptOptions.cs
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace OnnxStack.StableDiffusion.Config
 {
-    public class PromptOptions
+    public record PromptOptions
     {
         public DiffuserType DiffuserType { get; set; }
 

--- a/OnnxStack.StableDiffusion/Helpers/TensorHelper.cs
+++ b/OnnxStack.StableDiffusion/Helpers/TensorHelper.cs
@@ -247,15 +247,6 @@ namespace OnnxStack.StableDiffusion.Helpers
         }
 
 
-      
-
-
-
-
-
-
-
-
         /// <summary>
         /// Generate a random Tensor from a normal distribution with mean 0 and variance 1
         /// </summary>
@@ -279,58 +270,5 @@ namespace OnnxStack.StableDiffusion.Helpers
             return latents;
         }
 
-
-        /// <summary>
-        /// Splits the Tensor along axis 0.
-        /// </summary>
-        /// <param name="tensor">The tensor.</param>
-        /// <param name="count">The count.</param>
-        /// <param name="axis">The axis.</param>
-        /// <returns></returns>
-        /// <exception cref="System.NotImplementedException">Only axis 0 is supported</exception>
-        public static DenseTensor<float>[] Split(this DenseTensor<float> tensor, int count, int axis = 0)
-        {
-            if (axis != 0)
-                throw new NotImplementedException("Only axis 0 is supported");
-
-            var dimensions = tensor.Dimensions.ToArray();
-            dimensions[0] /= count;
-
-            var newLength = (int)tensor.Length / count;
-            var results = new DenseTensor<float>[count];
-            for (int i = 0; i < count; i++)
-            {
-                var start = i * newLength;
-                results[i] = new DenseTensor<float>(tensor.Buffer.Slice(start, newLength), dimensions);
-            }
-            return results;
-        }
-
-
-        /// <summary>
-        /// Joins the tensors across the 0 axis.
-        /// </summary>
-        /// <param name="tensors">The tensors.</param>
-        /// <param name="axis">The axis.</param>
-        /// <returns></returns>
-        /// <exception cref="System.NotImplementedException">Only axis 0 is supported</exception>
-        public static DenseTensor<float> Join(this IList<DenseTensor<float>> tensors, int axis = 0)
-        {
-            if (axis != 0)
-                throw new NotImplementedException("Only axis 0 is supported");
-
-            var tensor = tensors.First();
-            var dimensions = tensor.Dimensions.ToArray();
-            dimensions[0] *= tensors.Count;
-
-            var newLength = (int)tensor.Length;
-            var buffer = new float[newLength * tensors.Count].AsMemory();
-            for (int i = 0; i < tensors.Count(); i++)
-            {
-                var start = i * newLength;
-                tensors[i].Buffer.CopyTo(buffer[start..]);
-            }
-            return new DenseTensor<float>(buffer, dimensions);
-        }
     }
 }

--- a/OnnxStack.StableDiffusion/Pipelines/Base/IPipeline.cs
+++ b/OnnxStack.StableDiffusion/Pipelines/Base/IPipeline.cs
@@ -14,6 +14,13 @@ namespace OnnxStack.StableDiffusion.Pipelines
 {
     public interface IPipeline
     {
+
+        /// <summary>
+        /// Gets the name.
+        /// </summary>
+        string Name { get; }
+
+
         /// <summary>
         /// Gets the pipelines supported diffusers.
         /// </summary>
@@ -127,5 +134,17 @@ namespace OnnxStack.StableDiffusion.Pipelines
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns></returns>
         IAsyncEnumerable<BatchVideoResult> GenerateVideoBatchAsync(BatchOptions batchOptions, PromptOptions promptOptions, SchedulerOptions schedulerOptions = default, ControlNetModel controlNet = default, Action<DiffusionProgress> progressCallback = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Runs the video stream pipeline returning each frame as an OnnxImage.
+        /// </summary>
+        /// <param name="videoFrames">The video frames.</param>
+        /// <param name="promptOptions">The prompt options.</param>
+        /// <param name="schedulerOptions">The scheduler options.</param>
+        /// <param name="controlNet">The control net.</param>
+        /// <param name="progressCallback">The progress callback.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns></returns>
+        IAsyncEnumerable<OnnxImage> GenerateVideoStreamAsync(IAsyncEnumerable<OnnxImage> videoFrames, PromptOptions promptOptions, SchedulerOptions schedulerOptions = default, ControlNetModel controlNet = default, Action<DiffusionProgress> progressCallback = null, CancellationToken cancellationToken = default);
     }
 }

--- a/OnnxStack.StableDiffusion/Pipelines/Base/PipelineBase.cs
+++ b/OnnxStack.StableDiffusion/Pipelines/Base/PipelineBase.cs
@@ -162,6 +162,19 @@ namespace OnnxStack.StableDiffusion.Pipelines
 
 
         /// <summary>
+        /// Runs the video stream pipeline returning each frame as an OnnxImage.
+        /// </summary>
+        /// <param name="videoFrames">The video frames.</param>
+        /// <param name="promptOptions">The prompt options.</param>
+        /// <param name="schedulerOptions">The scheduler options.</param>
+        /// <param name="controlNet">The control net.</param>
+        /// <param name="progressCallback">The progress callback.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns></returns>
+        public abstract IAsyncEnumerable<OnnxImage> GenerateVideoStreamAsync(IAsyncEnumerable<OnnxImage> videoFrames, PromptOptions promptOptions, SchedulerOptions schedulerOptions = default, ControlNetModel controlNet = default, Action<DiffusionProgress> progressCallback = null, CancellationToken cancellationToken = default);
+
+
+        /// <summary>
         /// Creates the diffuser.
         /// </summary>
         /// <param name="diffuserType">Type of the diffuser.</param>


### PR DESCRIPTION
`Upscale` and `StableDiffusion` video pipelines use a large amount of RAM if the video resolution is large or it has a long duration.

At the moment video processing is buffered as we load all frames into RAM, this PR will introduce some methods to stream a video from disk frame by frame while writing each frame back to disk. This will reduce ram usage to a single input and output frame instead of full input + output video size.

Tasks:
- [x] Video stream methods
- [x] Upscale video stream
- [x] Feature Extractor video stream
- [x] StableDiffusion video stream


This should also enable live streaming via webcam in theory